### PR TITLE
Properly implement data types.

### DIFF
--- a/src/GCL/Common.hs
+++ b/src/GCL/Common.hs
@@ -90,7 +90,7 @@ instance Free Type where
   freeVars (TArray _ t _ ) = freeVars t
   freeVars (TTuple ts    ) = Set.unions (map freeVars ts)
   freeVars (TFunc t1 t2 _) = freeVars t1 <> freeVars t2
-  freeVars (TCon  _  ns _) = Set.fromList ns
+  freeVars (TApp l r _   ) = freeVars l <> freeVars r
   freeVars (TVar x _     ) = Set.singleton x
   freeVars (TMetaVar n   ) = Set.singleton n
 

--- a/src/GCL/Common.hs
+++ b/src/GCL/Common.hs
@@ -65,6 +65,7 @@ freeMetaVars (TArray _ t _ ) = freeMetaVars t
 freeMetaVars (TTuple ts    ) = Set.unions (map freeMetaVars ts)
 freeMetaVars (TFunc t1 t2 _) = freeMetaVars t1 <> freeMetaVars t2
 freeMetaVars (TApp l r _   ) = freeMetaVars l <> freeMetaVars r
+freeMetaVars (TData _ _ _  ) = mempty
 freeMetaVars (TVar _ _     ) = mempty
 freeMetaVars (TMetaVar n   ) = Set.singleton n
 
@@ -100,6 +101,7 @@ instance Free Type where
   freeVars (TTuple ts    ) = Set.unions (map freeVars ts)
   freeVars (TFunc t1 t2 _) = freeVars t1 <> freeVars t2
   freeVars (TApp l r _   ) = freeVars l <> freeVars r
+  freeVars (TData _ _ _  ) = mempty
   freeVars (TVar x _     ) = Set.singleton x
   freeVars (TMetaVar n   ) = Set.singleton n
 

--- a/src/GCL/Common.hs
+++ b/src/GCL/Common.hs
@@ -59,6 +59,15 @@ emptySubs = mempty
 emptyEnv :: Env a
 emptyEnv = mempty
 
+freeMetaVars :: Type -> Set Name
+freeMetaVars (TBase _ _    ) = mempty
+freeMetaVars (TArray _ t _ ) = freeMetaVars t
+freeMetaVars (TTuple ts    ) = Set.unions (map freeMetaVars ts)
+freeMetaVars (TFunc t1 t2 _) = freeMetaVars t1 <> freeMetaVars t2
+freeMetaVars (TApp l r _   ) = freeMetaVars l <> freeMetaVars r
+freeMetaVars (TVar _ _     ) = mempty
+freeMetaVars (TMetaVar n   ) = Set.singleton n
+
 -- A class of types for which we may compute their free variables.
 class Free a where
   freeVars :: a -> Set Name

--- a/src/GCL/Substitution.hs
+++ b/src/GCL/Substitution.hs
@@ -28,7 +28,6 @@ import           GCL.Common                     ( Free(freeVars)
                                                 , Counterous(..)
                                                 , Fresh(..)
                                                 , FreshState
-                                                , fresh
                                                 , freshPre
                                                 )
 import           GCL.Predicate                  ( PO(PO)

--- a/src/GCL/Type.hs
+++ b/src/GCL/Type.hs
@@ -150,9 +150,9 @@ instance CollectIds [Definition] where
                   case params of
                     [] -> con
                     n : ns -> formTy (TApp con n loc) ns loc
-            let newTypeInfos =
+            let newTypeInfos = -- TODO: Fix possible name collision.
                   map
-                    (\(TypeDefnCtor cn ts) -> (Index cn, TypeDefnCtorInfo (wrapTFunc ts (formTy (TVar name (locOf name)) ((`TVar` locOf args) <$> args) (name <--> args)))))
+                    (\(TypeDefnCtor cn ts) -> (Index cn, TypeDefnCtorInfo (wrapTFunc ts (formTy (TVar name (locOf name)) (TMetaVar <$> args) (name <--> args)))))
                     ctors
             let newTypeDefnInfos = (Index name, TypeDefnInfo args)
             modify (\(freshState, origTypeDefnInfos, origTypeInfos) -> (freshState, newTypeDefnInfos : origTypeDefnInfos, newTypeInfos <> origTypeInfos))

--- a/src/GCL/Type.hs
+++ b/src/GCL/Type.hs
@@ -152,7 +152,7 @@ instance CollectIds [Definition] where
                     n : ns -> formTy (TApp con n loc) ns loc
             let newTypeInfos = -- TODO: Fix possible name collision.
                   map
-                    (\(TypeDefnCtor cn ts) -> (Index cn, TypeDefnCtorInfo (wrapTFunc ts (formTy (TData name 1 {- FIXME: This is incorrect. -} (locOf name)) (TMetaVar <$> args) (name <--> args)))))
+                    (\(TypeDefnCtor cn ts) -> (Index cn, TypeDefnCtorInfo (wrapTFunc ts (formTy (TData name () (locOf name)) (TMetaVar <$> args) (name <--> args)))))
                     ctors
             let newTypeDefnInfos = (Index name, TypeDefnInfo args)
             modify (\(freshState, origTypeDefnInfos, origTypeInfos) -> (freshState, newTypeDefnInfos : origTypeDefnInfos, newTypeInfos <> origTypeInfos))

--- a/src/GCL/Type.hs
+++ b/src/GCL/Type.hs
@@ -622,8 +622,10 @@ unifies (TFunc t1 t2 _) (TFunc t3 t4 _) l = do
   s1 <- unifies t1 t3 l
   s2 <- unifies (subst s1 t2) (subst s1 t4) l
   return (s2 `compose` s1)
-unifies (TCon n1 args1 _) (TCon n2 args2 _) _
-  | n1 == n2 && length args1 == length args2 = return mempty
+unifies (TApp l1 r1 _) (TApp l2 r2 _) _ = do
+  s1 <- unifies l1 l2
+  s2 <- unifies (subst s1 l2) (subst s1 r2) l
+  return (s2 `compose` s1)
 unifies (TVar x _)   t            l          = bind x t l
 unifies t            (TVar x _)   l          = bind x t l
 unifies (TMetaVar x) t            l          = bind x t l

--- a/src/GCL/WP.hs
+++ b/src/GCL/WP.hs
@@ -24,7 +24,7 @@ import           GCL.WP.Type
 import qualified Syntax.Abstract               as A
 import qualified Syntax.Abstract.Operator      as A
 import qualified Syntax.Abstract.Util          as A
-import           Syntax.Common.Types           ( Name, nameToText)
+import           Syntax.Common.Types            ( nameToText )
 import GCL.WP.Struct
 import GCL.WP.WP
 import GCL.WP.SP

--- a/src/GCL/WP/Struct.hs
+++ b/src/GCL/WP/Struct.hs
@@ -17,11 +17,7 @@ import           GCL.Predicate                  ( InfMode(..)
 import           GCL.Predicate.Util             ( guardIf
                                                 , guardLoop
                                                 )
-import           GCL.Common                     ( Fresh(..)
-                                                , freshName
-                                                , freshName'
-                                                , freeVars
-                                                )
+import           GCL.Common                     ( freshName )
 import GCL.WP.Type
 import GCL.WP.Explanation
 import GCL.WP.Util
@@ -161,7 +157,7 @@ structFunctions (wpSegs, wpSStmts, wp, spSStmts) =
     (Bound (bnd `A.lt` oldbnd) NoLoc)
 
  structBlock :: Pred -> A.Program -> Pred -> WP ()
- structBlock pre (A.Program _ decls props stmts _) post = do
+ structBlock pre (A.Program _ decls _props stmts _) post = do
    let localNames = declaredNames decls
    (xs, ys) <- withLocalScopes (\scopes ->
                 withScopeExtension (map nameToText localNames)

--- a/src/GCL/WP/Type.hs
+++ b/src/GCL/WP/Type.hs
@@ -3,6 +3,7 @@
 
 module GCL.WP.Type where
 
+import           GHC.Generics                   ( Generic )
 import           Control.Monad.Except           ( Except )
 import           Control.Monad.RWS              ( MonadState(..)
                                                 , RWST(..) )
@@ -16,8 +17,7 @@ import GCL.Predicate                           ( InfMode(..)
                                                , PO(..), Pred(..), Spec (..))
 import qualified GCL.Substitution              as Substitution
 import qualified Syntax.Abstract               as A
-import           Syntax.Common.Types           ( Name )
-import GHC.Generics (Generic)
+
 -- The WP monad.
 
 type TM = Except StructError

--- a/src/GCL/WP/WP.hs
+++ b/src/GCL/WP/WP.hs
@@ -8,7 +8,6 @@ import           Control.Monad.Except           ( MonadError(throwError)
                                                 )
 import           Data.Text                      ( Text )
 import           Data.Loc                       ( Loc(..), locOf )
-import           Data.Set                       ( member )
 import           Data.Map                       ( fromList )
 import           GCL.Predicate                  ( Pred(..) )
 import           GCL.Predicate.Util             ( conjunct
@@ -17,7 +16,6 @@ import           GCL.Predicate.Util             ( conjunct
 import           GCL.Common                     ( Fresh(..)
                                                 , freshName
                                                 , freshName'
-                                                , freeVars
                                                 )
 import           Pretty                         ( toText )
 import GCL.WP.Type

--- a/src/Pretty/Abstract.hs
+++ b/src/Pretty/Abstract.hs
@@ -61,10 +61,8 @@ instance Pretty Definition where
 
 
 instance Pretty TypeDefnCtor where
-  pretty (TypeDefnCtor cn ts) = pretty cn <+> hsep (map wrap ts)
-   where
-    wrap t@TBase{} = pretty t
-    wrap t         = "(" <> pretty t <> ")"
+  pretty (TypeDefnCtor cn ts) = pretty cn <+> hsep (pretty <$> ts)
+
 --------------------------------------------------------------------------------
 
 -- | Stmt

--- a/src/Pretty/Concrete.hs
+++ b/src/Pretty/Concrete.hs
@@ -474,6 +474,7 @@ instance PrettyWithLoc Type where
   prettyWithLoc (TArray l a r b) =
     prettyWithLoc l <> prettyWithLoc a <> prettyWithLoc r <> prettyWithLoc b
   prettyWithLoc (TApp a b) = prettyWithLoc a <> prettyWithLoc b
+  prettyWithLoc (TData n ) = prettyWithLoc n
   prettyWithLoc (TVar i  ) = prettyWithLoc i
 
 --------------------------------------------------------------------------------

--- a/src/Pretty/Concrete.hs
+++ b/src/Pretty/Concrete.hs
@@ -473,7 +473,7 @@ instance PrettyWithLoc Type where
     prettyWithLoc a <> prettyWithLoc l <> prettyWithLoc b
   prettyWithLoc (TArray l a r b) =
     prettyWithLoc l <> prettyWithLoc a <> prettyWithLoc r <> prettyWithLoc b
-  prettyWithLoc (TCon a b) = prettyWithLoc a <> prettyWithLoc b
+  prettyWithLoc (TApp a b) = prettyWithLoc a <> prettyWithLoc b
   prettyWithLoc (TVar i  ) = prettyWithLoc i
 
 --------------------------------------------------------------------------------

--- a/src/Render/Syntax/Abstract.hs
+++ b/src/Render/Syntax/Abstract.hs
@@ -136,8 +136,8 @@ instance Render Type where
       <+> renderPrec (OpHOLE . TypeOp $ Arrow NoLoc) b
   renderPrec _ (TArray i b    _) = "array" <+> render i <+> "of" <+> render b
   renderPrec _ (TApp l r _     ) = render l <+> render r -- TODO: Deal with parentheses.
-  renderPrec _ (TVar i _       ) = "TVar" <+> render i
-  renderPrec _ (TMetaVar n     ) = "TMetaVar" <+> render n
+  renderPrec _ (TVar i _       ) = render i
+  renderPrec _ (TMetaVar n     ) = render n
 
 -- | Interval
 instance Render Interval where

--- a/src/Render/Syntax/Abstract.hs
+++ b/src/Render/Syntax/Abstract.hs
@@ -136,6 +136,7 @@ instance Render Type where
       <+> renderPrec (OpHOLE . TypeOp $ Arrow NoLoc) b
   renderPrec _ (TArray i b    _) = "array" <+> render i <+> "of" <+> render b
   renderPrec _ (TApp l r _     ) = render l <+> render r -- TODO: Deal with parentheses.
+  renderPrec _ (TData n _ _    ) = render n
   renderPrec _ (TVar i _       ) = render i
   renderPrec _ (TMetaVar n     ) = render n
 

--- a/src/Render/Syntax/Abstract.hs
+++ b/src/Render/Syntax/Abstract.hs
@@ -135,7 +135,7 @@ instance Render Type where
       <+> "→"
       <+> renderPrec (OpHOLE . TypeOp $ Arrow NoLoc) b
   renderPrec _ (TArray i b    _) = "array" <+> render i <+> "of" <+> render b
-  renderPrec _ (TApp l r _     ) = render l <+> render r -- TODO: Deal with parentheses.
+  renderPrec n (TApp l r _     ) = parensIf n Nothing $ renderPrec HOLEApp l <+> renderPrec AppHOLE r
   renderPrec _ (TData n _ _    ) = render n
   renderPrec _ (TVar i _       ) = render i
   renderPrec _ (TMetaVar n     ) = render n

--- a/src/Render/Syntax/Abstract.hs
+++ b/src/Render/Syntax/Abstract.hs
@@ -135,7 +135,7 @@ instance Render Type where
       <+> "→"
       <+> renderPrec (OpHOLE . TypeOp $ Arrow NoLoc) b
   renderPrec _ (TArray i b    _) = "array" <+> render i <+> "of" <+> render b
-  renderPrec _ (TCon   n args _) = render n <+> horzE (map render args)
+  renderPrec _ (TApp l r _     ) = render l <+> render r -- TODO: Deal with parentheses.
   renderPrec _ (TVar i _       ) = "TVar" <+> render i
   renderPrec _ (TMetaVar n     ) = "TMetaVar" <+> render n
 

--- a/src/Server/GoToDefn.hs
+++ b/src/Server/GoToDefn.hs
@@ -235,6 +235,7 @@ instance Collect LocationLinkToBe LocationLink Type where
     TTuple as    -> mapM_ collect as
     TFunc x y _  -> collect x >> collect y
     TApp  x y _  -> collect x >> collect y
+    TData {}     -> return () -- TODO:
     TVar _ _     -> return ()
     TMetaVar _   -> return ()
 

--- a/src/Server/GoToDefn.hs
+++ b/src/Server/GoToDefn.hs
@@ -234,7 +234,7 @@ instance Collect LocationLinkToBe LocationLink Type where
     TArray i x _ -> collect i >> collect x
     TTuple as    -> mapM_ collect as
     TFunc x y _  -> collect x >> collect y
-    TCon  x _ _  -> collect x
+    TApp  x y _  -> collect x >> collect y
     TVar _ _     -> return ()
     TMetaVar _   -> return ()
 

--- a/src/Server/GoToDefn.hs
+++ b/src/Server/GoToDefn.hs
@@ -235,7 +235,7 @@ instance Collect LocationLinkToBe LocationLink Type where
     TTuple as    -> mapM_ collect as
     TFunc x y _  -> collect x >> collect y
     TApp  x y _  -> collect x >> collect y
-    TData {}     -> return () -- TODO:
+    TData n _ _  -> collect n
     TVar _ _     -> return ()
     TMetaVar _   -> return ()
 

--- a/src/Server/Highlighting.hs
+++ b/src/Server/Highlighting.hs
@@ -107,9 +107,8 @@ instance Collect () Highlighting Declaration where
     collect a
 
 instance Collect () Highlighting TypeDefnCtor where
-  collect (TypeDefnCtor name types) = do
+  collect (TypeDefnCtor name _) = do
     collect (AsName name)
-    collect types
 
 instance Collect () Highlighting DeclBase where
   collect (DeclBase as _ b) = do
@@ -273,4 +272,5 @@ instance Collect () Highlighting Type where
     collect b
   -- TODO: handle type application collect
   collect TApp{}      = return ()
+  collect TData{}     = return () -- TODO: Fix this.
   collect (TVar name) = addHighlighting J.SttType [] name

--- a/src/Server/Highlighting.hs
+++ b/src/Server/Highlighting.hs
@@ -271,6 +271,6 @@ instance Collect () Highlighting Type where
     collect a
     addHighlighting J.SttOperator [] tok
     collect b
-  -- TODO: handle user defined type collect
-  collect TCon{}      = return ()
+  -- TODO: handle type application collect
+  collect TApp{}      = return ()
   collect (TVar name) = addHighlighting J.SttType [] name

--- a/src/Server/Highlighting.hs
+++ b/src/Server/Highlighting.hs
@@ -270,7 +270,8 @@ instance Collect () Highlighting Type where
     collect a
     addHighlighting J.SttOperator [] tok
     collect b
-  -- TODO: handle type application collect
-  collect TApp{}      = return ()
-  collect TData{}     = return () -- TODO: Fix this.
-  collect (TVar name) = addHighlighting J.SttType [] name
+  collect (TApp a b)  = do
+    collect a
+    collect b
+  collect (TData name) = addHighlighting J.SttType [] name
+  collect (TVar name)  = addHighlighting J.SttType [] name

--- a/src/Server/Hover.hs
+++ b/src/Server/Hover.hs
@@ -15,11 +15,9 @@ import           Data.Loc           ( Located
                                     , locOf
                                     )
 import           Data.Loc.Range
-import qualified GCL.Type           as TypeChecking
 import           Server.IntervalMap ( IntervalMap )
 import qualified Server.IntervalMap as IntervalMap
 import           Syntax.Abstract
-import           Syntax.Common
 import           Syntax.Typed                   as Typed
 
 collectHoverInfo :: Typed.TypedProgram -> IntervalMap (J.Hover, Type)
@@ -61,10 +59,10 @@ instance Collect Typed.TypedProgram where
 instance Collect Typed.TypedDefinition where
   collect (Typed.TypeDefn _ _ ctors _) = foldMap collect ctors
   collect (Typed.FuncDefnSig arg t prop _) = annotateType arg t <> maybe mempty collect prop
-  collect (Typed.FuncDefn name exprs) = foldMap collect exprs
+  collect (Typed.FuncDefn _name exprs) = foldMap collect exprs
 
 instance Collect Typed.TypedTypeDefnCtor where
-  collect (Typed.TypedTypeDefnCtor name tys) = mempty
+  collect (Typed.TypedTypeDefnCtor _name _tys) = mempty
 
 --------------------------------------------------------------------------------
 -- Declaration
@@ -79,7 +77,7 @@ instance Collect Typed.TypedDeclaration where
 instance Collect Typed.TypedStmt where
   collect (Typed.Skip _) = mempty
   collect (Typed.Abort _) = mempty
-  collect (Typed.Assign names exprs _) = foldMap collect exprs -- TODO: Display hover info for names.
+  collect (Typed.Assign _names exprs _) = foldMap collect exprs -- TODO: Display hover info for names.
   collect (Typed.AAssign arr index rhs _) = collect arr <> collect index <> collect rhs
   collect (Typed.Assert expr _) = collect expr
   collect (Typed.LoopInvariant inv bnd _) = collect inv <> collect bnd

--- a/src/Syntax/Abstract/Instances/Located.hs
+++ b/src/Syntax/Abstract/Instances/Located.hs
@@ -53,6 +53,7 @@ instance Located Type where
   locOf (TTuple _    ) = NoLoc
   locOf (TFunc _ _ l ) = l
   locOf (TApp  _ _ l ) = locOf l
+  locOf (TData _ _ l ) = l
   locOf (TVar _ l    ) = l
   locOf (TMetaVar _  ) = NoLoc
 

--- a/src/Syntax/Abstract/Instances/Located.hs
+++ b/src/Syntax/Abstract/Instances/Located.hs
@@ -52,7 +52,7 @@ instance Located Type where
   locOf (TArray _ _ l) = l
   locOf (TTuple _    ) = NoLoc
   locOf (TFunc _ _ l ) = l
-  locOf (TCon  _ _ l ) = locOf l
+  locOf (TApp  _ _ l ) = locOf l
   locOf (TVar _ l    ) = l
   locOf (TMetaVar _  ) = NoLoc
 

--- a/src/Syntax/Abstract/Types.hs
+++ b/src/Syntax/Abstract/Types.hs
@@ -40,7 +40,7 @@ data Definition =
     deriving (Eq, Show)
 
 -- constructor of type definition
-data TypeDefnCtor = TypeDefnCtor Name [Type]
+data TypeDefnCtor = TypeDefnCtor Name [Name]
   deriving (Eq, Show)
 
 --------------------------------------------------------------------------------
@@ -100,6 +100,7 @@ data Type
   | TTuple [Type]
   | TFunc Type Type Loc
   | TApp Type Type Loc
+  | TData Name Int Loc
   | TVar Name Loc
   | TMetaVar Name
   deriving (Eq, Show, Generic)

--- a/src/Syntax/Abstract/Types.hs
+++ b/src/Syntax/Abstract/Types.hs
@@ -100,7 +100,7 @@ data Type
   | TTuple [Type]
   | TFunc Type Type Loc
   | TApp Type Type Loc
-  | TData Name Int Loc
+  | TData Name () {- TODO: kind system -} Loc
   | TVar Name Loc
   | TMetaVar Name
   deriving (Eq, Show, Generic)

--- a/src/Syntax/Abstract/Types.hs
+++ b/src/Syntax/Abstract/Types.hs
@@ -99,7 +99,7 @@ data Type
   -- TTuple has no srcloc info because it has no conrete syntax at the moment 
   | TTuple [Type]
   | TFunc Type Type Loc
-  | TCon Name [Name] Loc
+  | TApp Type Type Loc
   | TVar Name Loc
   | TMetaVar Name
   deriving (Eq, Show, Generic)

--- a/src/Syntax/Abstract/Util.hs
+++ b/src/Syntax/Abstract/Util.hs
@@ -29,10 +29,10 @@ import           Syntax.Common                  ( Name(..)
     --Nothing
     --(locOf cn)
 
-wrapTFunc :: [Type] -> Type -> Type
+wrapTFunc :: [Name] -> Type -> Type
 wrapTFunc []       t  = t
-wrapTFunc [t     ] t0 = TFunc t t0 (locOf t)
-wrapTFunc (t : ts) t0 = let t0' = wrapTFunc ts t0 in TFunc t t0' (t <--> t0')
+wrapTFunc [t     ] t0 = TFunc (TMetaVar t) t0 (locOf t)
+wrapTFunc (t : ts) t0 = let t0' = wrapTFunc ts t0 in TFunc (TMetaVar t) t0' (t <--> t0')
 
 getGuards :: [GdCmd] -> [Expr]
 getGuards = fst . unzipGdCmds

--- a/src/Syntax/Concrete/Instances/Located.hs
+++ b/src/Syntax/Concrete/Instances/Located.hs
@@ -82,7 +82,7 @@ instance Located Type where
   locOf (TBase a       ) = locOf a
   locOf (TArray l _ _ r) = l <--> r
   locOf (TFunc l _ r   ) = l <--> r
-  locOf (TCon l r      ) = l <--> r
+  locOf (TApp l r      ) = l <--> r
   locOf (TVar x        ) = locOf x
 
 --------------------------------------------------------------------------------

--- a/src/Syntax/Concrete/Instances/Located.hs
+++ b/src/Syntax/Concrete/Instances/Located.hs
@@ -83,6 +83,7 @@ instance Located Type where
   locOf (TArray l _ _ r) = l <--> r
   locOf (TFunc l _ r   ) = l <--> r
   locOf (TApp l r      ) = l <--> r
+  locOf (TData name    ) = locOf name
   locOf (TVar x        ) = locOf x
 
 --------------------------------------------------------------------------------

--- a/src/Syntax/Concrete/Instances/ToAbstract.hs
+++ b/src/Syntax/Concrete/Instances/ToAbstract.hs
@@ -90,7 +90,7 @@ instance ToAbstract Definition [A.Definition] where
     return [A.FuncDefn name [wrapLam args body']]
 
 instance ToAbstract TypeDefnCtor A.TypeDefnCtor where
-  toAbstract (TypeDefnCtor c ts) = A.TypeDefnCtor c <$> toAbstract ts
+  toAbstract (TypeDefnCtor c ts) = return $ A.TypeDefnCtor c ts
 
 --------------------------------------------------------------------------------
 -- | Declaraion
@@ -192,6 +192,7 @@ instance ToAbstract Type A.Type where
       A.TFunc <$> toAbstract a <*> toAbstract b <*> pure (locOf t)
     (TApp l r) -> A.TApp <$> toAbstract l <*> toAbstract r <*> pure (l <--> r)
     (TVar a      ) -> pure $ A.TVar a (locOf t)
+    (TData n     ) -> pure $ A.TData n 1 (locOf t) -- FIXME: Do not limit the parameter count to 1.
     (TParen _ a _) -> do
       t' <- toAbstract a
       case t' of
@@ -200,6 +201,7 @@ instance ToAbstract Type A.Type where
         A.TTuple as'     -> pure $ A.TTuple as'
         A.TFunc a' b' _  -> pure $ A.TFunc a' b' (locOf t)
         A.TApp  a' b' _  -> pure $ A.TApp a' b' (locOf t)
+        A.TData name i _ -> pure $ A.TData name i (locOf t)
         A.TVar a' _      -> pure $ A.TVar a' (locOf t)
         A.TMetaVar a'    -> pure $ A.TMetaVar a'
 

--- a/src/Syntax/Concrete/Instances/ToAbstract.hs
+++ b/src/Syntax/Concrete/Instances/ToAbstract.hs
@@ -190,11 +190,7 @@ instance ToAbstract Type A.Type where
       A.TArray <$> toAbstract a <*> toAbstract b <*> pure (locOf t)
     (TFunc a _ b) ->
       A.TFunc <$> toAbstract a <*> toAbstract b <*> pure (locOf t)
-    (TCon n@(Name tn l) ns    ) 
-      | tn == "Int"  && null ns -> return $ A.TBase A.TInt l
-      | tn == "Bool" && null ns -> return $ A.TBase A.TBool l
-      | tn == "Char" && null ns -> return $ A.TBase A.TChar l
-      | otherwise -> return $ A.TCon n ns (n <--> ns)
+    (TApp l r) -> A.TApp <$> toAbstract l <*> toAbstract r <*> pure (l <--> r)
     (TVar a      ) -> pure $ A.TVar a (locOf t)
     (TParen _ a _) -> do
       t' <- toAbstract a
@@ -203,7 +199,7 @@ instance ToAbstract Type A.Type where
         A.TArray a' b' _ -> pure $ A.TArray a' b' (locOf t)
         A.TTuple as'     -> pure $ A.TTuple as'
         A.TFunc a' b' _  -> pure $ A.TFunc a' b' (locOf t)
-        A.TCon  a' b' _  -> pure $ A.TCon a' b' (locOf t)
+        A.TApp  a' b' _  -> pure $ A.TApp a' b' (locOf t)
         A.TVar a' _      -> pure $ A.TVar a' (locOf t)
         A.TMetaVar a'    -> pure $ A.TMetaVar a'
 

--- a/src/Syntax/Concrete/Instances/ToAbstract.hs
+++ b/src/Syntax/Concrete/Instances/ToAbstract.hs
@@ -192,7 +192,7 @@ instance ToAbstract Type A.Type where
       A.TFunc <$> toAbstract a <*> toAbstract b <*> pure (locOf t)
     (TApp l r) -> A.TApp <$> toAbstract l <*> toAbstract r <*> pure (l <--> r)
     (TVar a      ) -> pure $ A.TVar a (locOf t)
-    (TData n     ) -> pure $ A.TData n 1 (locOf t) -- FIXME: Do not limit the parameter count to 1.
+    (TData n     ) -> pure $ A.TData n () (locOf t)
     (TParen _ a _) -> do
       t' <- toAbstract a
       case t' of

--- a/src/Syntax/Concrete/Types.hs
+++ b/src/Syntax/Concrete/Types.hs
@@ -67,7 +67,7 @@ data Definition
   | FuncDefn Name [Name] (Token "=") Expr
   deriving (Eq, Show)
 
-data TypeDefnCtor = TypeDefnCtor Name [Type] deriving (Eq, Show)
+data TypeDefnCtor = TypeDefnCtor Name [Name] deriving (Eq, Show)
 
 --------------------------------------------------------------------------------
 -- | Declaration
@@ -141,6 +141,7 @@ data Type
   | TArray (Token "array") Interval (Token "of") Type
   | TFunc Type TokArrows Type
   | TApp Type Type
+  | TData Name -- TODO: add range
   | TVar Name
   deriving (Eq, Show)
 

--- a/src/Syntax/Concrete/Types.hs
+++ b/src/Syntax/Concrete/Types.hs
@@ -140,7 +140,7 @@ data Type
   | TBase TBase
   | TArray (Token "array") Interval (Token "of") Type
   | TFunc Type TokArrows Type
-  | TCon Name [Name]
+  | TApp Type Type
   | TVar Name
   deriving (Eq, Show)
 

--- a/src/Syntax/Parser.hs
+++ b/src/Syntax/Parser.hs
@@ -644,7 +644,7 @@ type' = do
   makeExprParser term table <?> "type"
  where
   table :: [[Operator Parser Type]]
-  table = [[InfixR function]]
+  table = [[InfixL (return TApp)], [InfixR function]]
 
   function :: Parser (Type -> Type -> Type)
   function = do
@@ -652,17 +652,13 @@ type' = do
     return $ \x y -> TFunc x arrow y
 
   term :: Parser Type
-  term = parensType <|> array <|> try typeVar <|> typeName <?> "type term"
+  term = parensType <|> array <|> typeVar <?> "type term"
 
   parensType :: Parser Type
   parensType = TParen <$> tokenParenOpen <*> type' <*> tokenParenClose
 
-
   typeVar :: Parser Type
-  typeVar = TVar <$> lower
-
-  typeName :: Parser Type
-  typeName = TApp <$> (TVar <$> identifier) <*> (TVar <$> identifier) -- TODO: This does not work well.
+  typeVar = TVar <$> identifier
 
   array :: Parser Type
   array = TArray <$> tokenArray <*> interval <*> tokenOf <*> type'

--- a/src/Syntax/Parser.hs
+++ b/src/Syntax/Parser.hs
@@ -662,7 +662,7 @@ type' = do
   typeVar = TVar <$> lower
 
   typeName :: Parser Type
-  typeName = TCon <$> upper <*> many lower
+  typeName = TApp <$> (TVar <$> identifier) <*> (TVar <$> identifier) -- TODO: This does not work well.
 
   array :: Parser Type
   array = TArray <$> tokenArray <*> interval <*> tokenOf <*> type'

--- a/src/Syntax/Parser/Lexer.hs
+++ b/src/Syntax/Parser/Lexer.hs
@@ -88,7 +88,10 @@ data Tok
   | TokDeclClose
   | -- expression
     TokUnderscore
-
+    -- types
+  | TokIntType
+  | TokBoolType
+  | TokCharType
     -- operators
   | TokEQ
   | TokNEQ
@@ -132,7 +135,7 @@ data Tok
   | TokChar Char
   | TokTrue
   | TokFalse
-  
+
   -- tokens for proof block {- #anchor ...} or block comment {- ... -}
   | TokProof String String String -- anchor, contents, full-text containing "{-", "-}"
   deriving (Eq, Ord)
@@ -224,6 +227,9 @@ instance Show Tok where
     TokChar      c       -> "'" <> show c <> "'"
     TokTrue              -> "True"
     TokFalse             -> "False"
+    TokIntType           -> "Int"
+    TokBoolType          -> "Bool"
+    TokCharType          -> "Char"
     TokProof s _ _       -> "{- #" ++ s ++ " ...-}"
 
 type TokStream = TokenStream (L Tok)
@@ -391,6 +397,12 @@ tokRE =
     <$  string "True"
     <|> TokFalse
     <$  string "False"
+    <|> TokIntType
+    <$  string "Int"
+    <|> TokBoolType
+    <$  string "Bool"
+    <|> TokCharType
+    <$  string "Char"
     <|> TokUpperName
     .   Text.pack
     <$> upperNameRE

--- a/src/Syntax/Typed.hs
+++ b/src/Syntax/Typed.hs
@@ -19,7 +19,7 @@ data TypedDefinition
   | FuncDefn Name [TypedExpr]
   deriving (Eq, Show)
 
-data TypedTypeDefnCtor = TypedTypeDefnCtor Name [Type]
+data TypedTypeDefnCtor = TypedTypeDefnCtor Name [Name]
   deriving (Eq, Show)
 
 data TypedDeclaration


### PR DESCRIPTION
This PR implement data types "properly." it's worth noting that in this implementation, type parameters are all first-order, which means they all have kind `*` (only in theory; in reality we do not have a kind system yet.) We don't even check the number of type parameters yet because naturally a type application (`TApp`) cannot be unified with a type constructor (`TData`.) Therefore, malformed types cannot pass the type checker.