### PR TITLE
Implement `Chain` as a data type.

### DIFF
--- a/src/GCL/Common.hs
+++ b/src/GCL/Common.hs
@@ -90,7 +90,7 @@ instance Free Type where
   freeVars (TArray _ t _ ) = freeVars t
   freeVars (TTuple ts    ) = Set.unions (map freeVars ts)
   freeVars (TFunc t1 t2 _) = freeVars t1 <> freeVars t2
-  freeVars (TCon  _  ns _) = Set.fromList ns
+  freeVars (TApp l r _   ) = freeVars l <> freeVars r
   freeVars (TVar x _     ) = Set.singleton x
   freeVars (TMetaVar n   ) = Set.singleton n
 

--- a/src/GCL/Common.hs
+++ b/src/GCL/Common.hs
@@ -65,6 +65,7 @@ freeMetaVars (TArray _ t _ ) = freeMetaVars t
 freeMetaVars (TTuple ts    ) = Set.unions (map freeMetaVars ts)
 freeMetaVars (TFunc t1 t2 _) = freeMetaVars t1 <> freeMetaVars t2
 freeMetaVars (TApp l r _   ) = freeMetaVars l <> freeMetaVars r
+freeMetaVars (TData _ _ _  ) = mempty
 freeMetaVars (TVar _ _     ) = mempty
 freeMetaVars (TMetaVar n   ) = Set.singleton n
 
@@ -100,6 +101,7 @@ instance Free Type where
   freeVars (TTuple ts    ) = Set.unions (map freeVars ts)
   freeVars (TFunc t1 t2 _) = freeVars t1 <> freeVars t2
   freeVars (TApp l r _   ) = freeVars l <> freeVars r
+  freeVars (TData _ _ _  ) = mempty
   freeVars (TVar x _     ) = Set.singleton x
   freeVars (TMetaVar n   ) = Set.singleton n
 

--- a/src/GCL/Common.hs
+++ b/src/GCL/Common.hs
@@ -59,6 +59,15 @@ emptySubs = mempty
 emptyEnv :: Env a
 emptyEnv = mempty
 
+freeMetaVars :: Type -> Set Name
+freeMetaVars (TBase _ _    ) = mempty
+freeMetaVars (TArray _ t _ ) = freeMetaVars t
+freeMetaVars (TTuple ts    ) = Set.unions (map freeMetaVars ts)
+freeMetaVars (TFunc t1 t2 _) = freeMetaVars t1 <> freeMetaVars t2
+freeMetaVars (TApp l r _   ) = freeMetaVars l <> freeMetaVars r
+freeMetaVars (TVar _ _     ) = mempty
+freeMetaVars (TMetaVar n   ) = Set.singleton n
+
 -- A class of types for which we may compute their free variables.
 class Free a where
   freeVars :: a -> Set Name

--- a/src/GCL/Substitution.hs
+++ b/src/GCL/Substitution.hs
@@ -28,7 +28,6 @@ import           GCL.Common                     ( Free(freeVars)
                                                 , Counterous(..)
                                                 , Fresh(..)
                                                 , FreshState
-                                                , fresh
                                                 , freshPre
                                                 )
 import           GCL.Predicate                  ( PO(PO)

--- a/src/GCL/Substitution.hs
+++ b/src/GCL/Substitution.hs
@@ -33,7 +33,8 @@ import           GCL.Common                     ( Free(freeVars)
 import           GCL.Predicate                  ( PO(PO)
                                                 , Pred(..)
                                                 )
-import           Syntax.Abstract                ( CaseClause(..)
+import           Syntax.Abstract                ( Chain(..)
+                                                , CaseClause(..)
                                                 , Expr(..)
                                                 , FuncClause(..)
                                                 , Mapping
@@ -215,7 +216,7 @@ instance Substitutable Expr where
 
     Op{}              -> return expr
 
-    Chain {} -> return expr -- FIXME: 
+    Chain ch          -> Chain <$> subst mapping ch
 
     App f      x    l -> App <$> subst mapping f <*> subst mapping x <*> pure l
 
@@ -297,6 +298,11 @@ instance Substitutable Expr where
       cases' <- forM cases
         $ \(CaseClause patt body) -> CaseClause patt <$> subst mapping body
       return $ Case e cases' l
+
+instance Substitutable Chain where
+  subst mapping ch = case ch of
+    Pure expr loc -> Pure <$> subst mapping expr <*> pure loc
+    More ch' op expr loc -> More <$> subst mapping ch' <*> pure op <*> subst mapping expr <*> pure loc
 
 instance Substitutable FuncClause where
   subst mapping (FuncClause patterns body) = do

--- a/src/GCL/Substitution.hs
+++ b/src/GCL/Substitution.hs
@@ -215,6 +215,8 @@ instance Substitutable Expr where
 
     Op{}              -> return expr
 
+    Chain {} -> return expr -- FIXME: 
+
     App f      x    l -> App <$> subst mapping f <*> subst mapping x <*> pure l
 
     Lam binder body l -> do

--- a/src/GCL/Type.hs
+++ b/src/GCL/Type.hs
@@ -548,11 +548,6 @@ instance Elab Chain where -- TODO: Make sure the below implementation is correct
     return (Just $ subst unifyTy tv, subst sub $ Typed.More (Typed.Pure typedExpr1) opTyped (subst unifyTy opTy') typedExpr2, sub)
   elaborate (Pure _expr _loc) _ = error "Chain of length 1 shouldn't exist."
 
-instance Elab Op where
-  elaborate (ChainOp op) = elaborate op
-  elaborate (ArithOp op) = elaborate op
-  elaborate (TypeOp op) = elaborate op
-
 instance Elab ChainOp where
   elaborate (EQProp  l) _ = return (Just $ tBool .-> tBool .-> tBool $ l, ChainOp $ EQProp l, mempty)
   elaborate (EQPropU l) _ = return (Just $ tBool .-> tBool .-> tBool $ l, ChainOp $ EQPropU l, mempty)

--- a/src/GCL/Type.hs
+++ b/src/GCL/Type.hs
@@ -150,9 +150,9 @@ instance CollectIds [Definition] where
                   case params of
                     [] -> con
                     n : ns -> formTy (TApp con n loc) ns loc
-            let newTypeInfos =
+            let newTypeInfos = -- TODO: Fix possible name collision.
                   map
-                    (\(TypeDefnCtor cn ts) -> (Index cn, TypeDefnCtorInfo (wrapTFunc ts (formTy (TVar name (locOf name)) ((`TVar` locOf args) <$> args) (name <--> args)))))
+                    (\(TypeDefnCtor cn ts) -> (Index cn, TypeDefnCtorInfo (wrapTFunc ts (formTy (TVar name (locOf name)) (TMetaVar <$> args) (name <--> args)))))
                     ctors
             let newTypeDefnInfos = (Index name, TypeDefnInfo args)
             modify (\(freshState, origTypeDefnInfos, origTypeInfos) -> (freshState, newTypeDefnInfos : origTypeDefnInfos, newTypeInfos <> origTypeInfos))

--- a/src/GCL/Type.hs
+++ b/src/GCL/Type.hs
@@ -152,7 +152,7 @@ instance CollectIds [Definition] where
                     n : ns -> formTy (TApp con n loc) ns loc
             let newTypeInfos = -- TODO: Fix possible name collision.
                   map
-                    (\(TypeDefnCtor cn ts) -> (Index cn, TypeDefnCtorInfo (wrapTFunc ts (formTy (TData name 1 {- FIXME: This is incorrect. -} (locOf name)) (TMetaVar <$> args) (name <--> args)))))
+                    (\(TypeDefnCtor cn ts) -> (Index cn, TypeDefnCtorInfo (wrapTFunc ts (formTy (TData name () (locOf name)) (TMetaVar <$> args) (name <--> args)))))
                     ctors
             let newTypeDefnInfos = (Index name, TypeDefnInfo args)
             modify (\(freshState, origTypeDefnInfos, origTypeInfos) -> (freshState, newTypeDefnInfos : origTypeDefnInfos, newTypeInfos <> origTypeInfos))

--- a/src/GCL/Type.hs
+++ b/src/GCL/Type.hs
@@ -435,6 +435,8 @@ instance Elab Expr where
     (ty, op, sub) <- elaborate o env
     ty' <- instantiate $ fromJust ty
     return (Just ty', subst sub (Typed.Op op ty'), sub)
+  elaborate (Chain ch) env = undefined -- FIXME:
+  {-
   -- TODO: Make sure the below implementation is correct, especially when the ChainOp is polymorphic. (edit: apprently it's incorrect)
   elaborate (App (App (Op op@(ChainOp _)) e1 _) e2 l) env = do
     (opTy, opTyped, opSub) <- elaborate op env
@@ -453,6 +455,7 @@ instance Elab Expr where
     vSub <- unifies (subst s2 (fromJust t2) ~-> subst s2 (fromJust t2) ~-> v) (subst opSub $ fromJust opTy) l
     let sub = s1 <> s2
     pure (Just $ subst vSub v, subst sub (Typed.App (Typed.App (Typed.Op opTyped $ subst opSub $ fromJust opTy) typed1 $ locOf e1) typed2 l), sub)
+  -}
   -- Γ ⊢ e1 ↑ (s1, t1)
   -- s1 Γ ⊢ e2 ↑ (s2, t2)
   -- b fresh   v = unify (s2 t1, t2 -> b)

--- a/src/GCL/Type.hs
+++ b/src/GCL/Type.hs
@@ -233,7 +233,6 @@ type family Typed untyped where
   Typed Expr = Typed.TypedExpr
   Typed Chain = Typed.TypedChain
   Typed Name = Name
-  Typed Op = Op
   Typed ChainOp = Op
   Typed ArithOp = Op
   Typed TypeOp = Op
@@ -537,7 +536,7 @@ instance Elab Chain where -- TODO: Make sure the below implementation is correct
     unifyTy <- unifies (fromJust ty1 ~-> fromJust ty2 ~-> tv) opTy' loc2
     let sub = chainSub <> opSub <> sub1 <> sub2
     return (Just $ subst unifyTy tv, subst sub $ Typed.More typedChain opTyped (subst unifyTy opTy') typedExpr2, sub)
-  elaborate (More (Pure e1 loc1) op e2 loc2) env = do
+  elaborate (More (Pure e1 _loc1) op e2 loc2) env = do
     tv <- freshVar
     (opTy, opTyped, opSub) <- elaborate op env
     opTy' <- instantiate $ fromJust opTy

--- a/src/GCL/Type.hs
+++ b/src/GCL/Type.hs
@@ -622,8 +622,10 @@ unifies (TFunc t1 t2 _) (TFunc t3 t4 _) l = do
   s1 <- unifies t1 t3 l
   s2 <- unifies (subst s1 t2) (subst s1 t4) l
   return (s2 `compose` s1)
-unifies (TCon n1 args1 _) (TCon n2 args2 _) _
-  | n1 == n2 && length args1 == length args2 = return mempty
+unifies (TApp l1 r1 _) (TApp l2 r2 _) _ = do
+  s1 <- unifies l1 l2
+  s2 <- unifies (subst s1 l2) (subst s1 r2) l
+  return (s2 `compose` s1)
 unifies (TVar x _)   t            l          = bind x t l
 unifies t            (TVar x _)   l          = bind x t l
 unifies (TMetaVar x) t            l          = bind x t l

--- a/src/GCL/WP.hs
+++ b/src/GCL/WP.hs
@@ -24,7 +24,7 @@ import           GCL.WP.Type
 import qualified Syntax.Abstract               as A
 import qualified Syntax.Abstract.Operator      as A
 import qualified Syntax.Abstract.Util          as A
-import           Syntax.Common.Types           ( Name, nameToText)
+import           Syntax.Common.Types            ( nameToText )
 import GCL.WP.Struct
 import GCL.WP.WP
 import GCL.WP.SP

--- a/src/GCL/WP/Struct.hs
+++ b/src/GCL/WP/Struct.hs
@@ -17,11 +17,7 @@ import           GCL.Predicate                  ( InfMode(..)
 import           GCL.Predicate.Util             ( guardIf
                                                 , guardLoop
                                                 )
-import           GCL.Common                     ( Fresh(..)
-                                                , freshName
-                                                , freshName'
-                                                , freeVars
-                                                )
+import           GCL.Common                     ( freshName )
 import GCL.WP.Type
 import GCL.WP.Explanation
 import GCL.WP.Util
@@ -161,7 +157,7 @@ structFunctions (wpSegs, wpSStmts, wp, spSStmts) =
     (Bound (bnd `A.lt` oldbnd) NoLoc)
 
  structBlock :: Pred -> A.Program -> Pred -> WP ()
- structBlock pre (A.Program _ decls props stmts _) post = do
+ structBlock pre (A.Program _ decls _props stmts _) post = do
    let localNames = declaredNames decls
    (xs, ys) <- withLocalScopes (\scopes ->
                 withScopeExtension (map nameToText localNames)

--- a/src/GCL/WP/Type.hs
+++ b/src/GCL/WP/Type.hs
@@ -3,6 +3,7 @@
 
 module GCL.WP.Type where
 
+import           GHC.Generics                   ( Generic )
 import           Control.Monad.Except           ( Except )
 import           Control.Monad.RWS              ( MonadState(..)
                                                 , RWST(..) )
@@ -16,8 +17,7 @@ import GCL.Predicate                           ( InfMode(..)
                                                , PO(..), Pred(..), Spec (..))
 import qualified GCL.Substitution              as Substitution
 import qualified Syntax.Abstract               as A
-import           Syntax.Common.Types           ( Name )
-import GHC.Generics (Generic)
+
 -- The WP monad.
 
 type TM = Except StructError

--- a/src/GCL/WP/WP.hs
+++ b/src/GCL/WP/WP.hs
@@ -8,7 +8,6 @@ import           Control.Monad.Except           ( MonadError(throwError)
                                                 )
 import           Data.Text                      ( Text )
 import           Data.Loc                       ( Loc(..), locOf )
-import           Data.Set                       ( member )
 import           Data.Map                       ( fromList )
 import           GCL.Predicate                  ( Pred(..) )
 import           GCL.Predicate.Util             ( conjunct
@@ -17,7 +16,6 @@ import           GCL.Predicate.Util             ( conjunct
 import           GCL.Common                     ( Fresh(..)
                                                 , freshName
                                                 , freshName'
-                                                , freeVars
                                                 )
 import           Pretty                         ( toText )
 import GCL.WP.Type

--- a/src/Pretty/Abstract.hs
+++ b/src/Pretty/Abstract.hs
@@ -61,10 +61,8 @@ instance Pretty Definition where
 
 
 instance Pretty TypeDefnCtor where
-  pretty (TypeDefnCtor cn ts) = pretty cn <+> hsep (map wrap ts)
-   where
-    wrap t@TBase{} = pretty t
-    wrap t         = "(" <> pretty t <> ")"
+  pretty (TypeDefnCtor cn ts) = pretty cn <+> hsep (pretty <$> ts)
+
 --------------------------------------------------------------------------------
 
 -- | Stmt

--- a/src/Pretty/Concrete.hs
+++ b/src/Pretty/Concrete.hs
@@ -474,6 +474,7 @@ instance PrettyWithLoc Type where
   prettyWithLoc (TArray l a r b) =
     prettyWithLoc l <> prettyWithLoc a <> prettyWithLoc r <> prettyWithLoc b
   prettyWithLoc (TApp a b) = prettyWithLoc a <> prettyWithLoc b
+  prettyWithLoc (TData n ) = prettyWithLoc n
   prettyWithLoc (TVar i  ) = prettyWithLoc i
 
 --------------------------------------------------------------------------------

--- a/src/Pretty/Concrete.hs
+++ b/src/Pretty/Concrete.hs
@@ -383,7 +383,7 @@ handleArithOp op = case classify (ArithOp op) of -- TODO: rewrite `classify` to 
     return $ prettyWithLoc p <> prettyWithLoc op
 
 handleChain :: Chain -> Variadic Expr (DocWithLoc ann)
-handleChain chain = case chain of -- TODO: This might be incorrect.
+handleChain chain = case chain of
   Pure expr -> handleExpr expr
   More ch op expr -> do
     ch' <- handleChain ch
@@ -448,7 +448,7 @@ showWithParentheses expr = case handleExpr' expr of
         ps <- handleExpr' p
         return $ "(" <> ps <> show (pretty op) <> ")"
 
-    handleChain' :: Chain -> Variadic Expr String -- TODO: This is likely incorrect and require further investigation.
+    handleChain' :: Chain -> Variadic Expr String
     handleChain' chain = case chain of
       Pure expr' -> handleExpr' expr'
       More ch op ex -> do

--- a/src/Pretty/Concrete.hs
+++ b/src/Pretty/Concrete.hs
@@ -331,7 +331,7 @@ handleExpr (Paren l x r) =
 handleExpr (Var   x) = return $ prettyWithLoc x
 handleExpr (Const x) = return $ prettyWithLoc x
 handleExpr (Lit   x) = return $ prettyWithLoc x
-handleExpr (Op    x) = handleOp x
+handleExpr (Op    x) = handleArithOp x
 handleExpr (Chain c) = handleChain c
 handleExpr (Arr arr l i r) =
   return
@@ -361,8 +361,8 @@ handleExpr (Case a expr b cases) =
     <> prettyWithLoc b
     <> prettyWithLoc cases
 
-handleOp :: Op -> Variadic Expr (DocWithLoc ann)
-handleOp op = case classify op of
+handleArithOp :: ArithOp -> Variadic Expr (DocWithLoc ann)
+handleArithOp op = case classify (ArithOp op) of -- TODO: rewrite `classify` to only handle `ArithOp`s.
   (Infix, _) -> do
     p <- var
     q <- var
@@ -403,7 +403,7 @@ showWithParentheses expr = case handleExpr' expr of
       LitInt n _ -> return $ show n
       LitBool b _ -> return $ show b
       LitChar c _ -> return $ show c
-    handleExpr' (Op    x) = handleOp' x
+    handleExpr' (Op    x) = handleArithOp' x
     handleExpr' (Chain c) = handleChain' c
     handleExpr' (Arr arr _ i _) = do
       arrs <- handleExpr' arr
@@ -419,8 +419,8 @@ showWithParentheses expr = case handleExpr' expr of
     handleExpr' c@Case {} =
       return $ show $ pretty c
 
-    handleOp' :: Op -> Variadic Expr String
-    handleOp' op = case classify op of
+    handleArithOp' :: ArithOp -> Variadic Expr String
+    handleArithOp' op = case classify (ArithOp op) of
       (Infix, _) -> do
         p <- var
         q <- var

--- a/src/Pretty/Concrete.hs
+++ b/src/Pretty/Concrete.hs
@@ -473,7 +473,7 @@ instance PrettyWithLoc Type where
     prettyWithLoc a <> prettyWithLoc l <> prettyWithLoc b
   prettyWithLoc (TArray l a r b) =
     prettyWithLoc l <> prettyWithLoc a <> prettyWithLoc r <> prettyWithLoc b
-  prettyWithLoc (TCon a b) = prettyWithLoc a <> prettyWithLoc b
+  prettyWithLoc (TApp a b) = prettyWithLoc a <> prettyWithLoc b
   prettyWithLoc (TVar i  ) = prettyWithLoc i
 
 --------------------------------------------------------------------------------

--- a/src/Render/Predicate.hs
+++ b/src/Render/Predicate.hs
@@ -10,8 +10,8 @@ import           GCL.WP.Type
 import           Render.Class
 import           Render.Element
 import           Render.Syntax.Abstract         ( )
-import           Syntax.Abstract.Types          (Expr(..))
-import           Syntax.Common.Types (Op(..), ArithOp (..))
+import           Syntax.Abstract.Types          ( Expr(..) )
+import           Syntax.Common.Types            ( ArithOp (..) )
 
 instance Render StructWarning where
   render (MissingBound _)
@@ -71,7 +71,7 @@ exprOfPred p = case p of
   Negate pr -> 
     let ex = exprOfPred pr
     in App (Op $ NegU NoLoc) ex (locOf ex)
-  where
+  where -- TODO: This requires further investigation. Maybe we don't need `Op` here
     conjOp = Op $ ConjU NoLoc
     disjOp = Op $ DisjU NoLoc
     makeOpExpr :: Expr -> Expr -> Expr -> Expr

--- a/src/Render/Predicate.hs
+++ b/src/Render/Predicate.hs
@@ -70,10 +70,10 @@ exprOfPred p = case p of
                            exprs
   Negate pr -> 
     let ex = exprOfPred pr
-    in App (Op $ ArithOp $ NegU NoLoc) ex (locOf ex)
+    in App (Op $ NegU NoLoc) ex (locOf ex)
   where
-    conjOp = Op (ArithOp (ConjU NoLoc))
-    disjOp = Op (ArithOp (DisjU NoLoc))
+    conjOp = Op $ ConjU NoLoc
+    disjOp = Op $ DisjU NoLoc
     makeOpExpr :: Expr -> Expr -> Expr -> Expr
     makeOpExpr op x y = App (App op x (locOf x)) y (locOf y)
 

--- a/src/Render/Syntax/Abstract.hs
+++ b/src/Render/Syntax/Abstract.hs
@@ -136,8 +136,8 @@ instance Render Type where
       <+> renderPrec (OpHOLE . TypeOp $ Arrow NoLoc) b
   renderPrec _ (TArray i b    _) = "array" <+> render i <+> "of" <+> render b
   renderPrec _ (TApp l r _     ) = render l <+> render r -- TODO: Deal with parentheses.
-  renderPrec _ (TVar i _       ) = "TVar" <+> render i
-  renderPrec _ (TMetaVar n     ) = "TMetaVar" <+> render n
+  renderPrec _ (TVar i _       ) = render i
+  renderPrec _ (TMetaVar n     ) = render n
 
 -- | Interval
 instance Render Interval where

--- a/src/Render/Syntax/Abstract.hs
+++ b/src/Render/Syntax/Abstract.hs
@@ -136,6 +136,7 @@ instance Render Type where
       <+> renderPrec (OpHOLE . TypeOp $ Arrow NoLoc) b
   renderPrec _ (TArray i b    _) = "array" <+> render i <+> "of" <+> render b
   renderPrec _ (TApp l r _     ) = render l <+> render r -- TODO: Deal with parentheses.
+  renderPrec _ (TData n _ _    ) = render n
   renderPrec _ (TVar i _       ) = render i
   renderPrec _ (TMetaVar n     ) = render n
 

--- a/src/Render/Syntax/Abstract.hs
+++ b/src/Render/Syntax/Abstract.hs
@@ -43,15 +43,15 @@ handleExpr _ (Var   x l) = tempHandleLoc l $ render x
 handleExpr _ (Const x l) = tempHandleLoc l $ render x
 handleExpr _ (Lit   x l) = tempHandleLoc l $ render x
 handleExpr _ (Op _     ) = error "erroneous syntax given to render"
-handleExpr n (Chain ch ) = render ch
+handleExpr _ (Chain ch ) = render ch
 handleExpr n (App (App (Op op) left _) right _) =  --binary operators
-  parensIf n (Just op) $ 
-  renderPrec (HOLEOp op) left 
+  parensIf n (Just (ArithOp op)) $ 
+  renderPrec (HOLEOp (ArithOp op)) left 
        <+> render op
-  <+> renderPrec (OpHOLE op) right
-handleExpr n (App (Op op) e _) = case classify op of --unary operators, this case shouldn't be former than the binary case
-  (Prefix, _) -> parensIf n (Just op) $ render op <+> renderPrec (OpHOLE op) e
-  (Postfix, _) -> parensIf n (Just op) $ renderPrec (HOLEOp op) e <+>  render op
+  <+> renderPrec (OpHOLE (ArithOp op)) right
+handleExpr n (App (Op op) e _) = case classify (ArithOp op) of --unary operators, this case shouldn't be former than the binary case
+  (Prefix, _) -> parensIf n (Just (ArithOp op)) $ render op <+> renderPrec (OpHOLE (ArithOp op)) e
+  (Postfix, _) -> parensIf n (Just (ArithOp op)) $ renderPrec (HOLEOp (ArithOp op)) e <+>  render op
   _ -> error "erroneous syntax given to render"
 handleExpr n (App f e _) =  -- should only be normal applications
   parensIf n Nothing $ renderPrec HOLEApp f <+> renderPrec AppHOLE e
@@ -76,12 +76,12 @@ handleExpr _ (Quant op xs r t _) =
     <+> render t
     <+> "⟩"
  where
-  renderQOp (Op (ArithOp (Conj  _))) = "∀"
-  renderQOp (Op (ArithOp (ConjU _))) = "∀"
-  renderQOp (Op (ArithOp (Disj  _))) = "∃"
-  renderQOp (Op (ArithOp (DisjU _))) = "∃"
-  renderQOp (Op (ArithOp (Add   _))) = "Σ"
-  renderQOp (Op (ArithOp (Mul   _))) = "Π"
+  renderQOp (Op (Conj  _)) = "∀"
+  renderQOp (Op (ConjU _)) = "∀"
+  renderQOp (Op (Disj  _)) = "∃"
+  renderQOp (Op (DisjU _)) = "∃"
+  renderQOp (Op (Add   _)) = "Σ"
+  renderQOp (Op (Mul   _)) = "Π"
   renderQOp (Op op'                ) = render op'
   renderQOp op'                      = render op'
 handleExpr n (RedexKernel name _value _freeVars mappings) =

--- a/src/Render/Syntax/Abstract.hs
+++ b/src/Render/Syntax/Abstract.hs
@@ -135,7 +135,7 @@ instance Render Type where
       <+> "→"
       <+> renderPrec (OpHOLE . TypeOp $ Arrow NoLoc) b
   renderPrec _ (TArray i b    _) = "array" <+> render i <+> "of" <+> render b
-  renderPrec _ (TApp l r _     ) = render l <+> render r -- TODO: Deal with parentheses.
+  renderPrec n (TApp l r _     ) = parensIf n Nothing $ renderPrec HOLEApp l <+> renderPrec AppHOLE r
   renderPrec _ (TData n _ _    ) = render n
   renderPrec _ (TVar i _       ) = render i
   renderPrec _ (TMetaVar n     ) = render n

--- a/src/Render/Syntax/Abstract.hs
+++ b/src/Render/Syntax/Abstract.hs
@@ -135,7 +135,7 @@ instance Render Type where
       <+> "→"
       <+> renderPrec (OpHOLE . TypeOp $ Arrow NoLoc) b
   renderPrec _ (TArray i b    _) = "array" <+> render i <+> "of" <+> render b
-  renderPrec _ (TCon   n args _) = render n <+> horzE (map render args)
+  renderPrec _ (TApp l r _     ) = render l <+> render r -- TODO: Deal with parentheses.
   renderPrec _ (TVar i _       ) = "TVar" <+> render i
   renderPrec _ (TMetaVar n     ) = "TMetaVar" <+> render n
 

--- a/src/Render/Syntax/Abstract.hs
+++ b/src/Render/Syntax/Abstract.hs
@@ -43,8 +43,7 @@ handleExpr _ (Var   x l) = tempHandleLoc l $ render x
 handleExpr _ (Const x l) = tempHandleLoc l $ render x
 handleExpr _ (Lit   x l) = tempHandleLoc l $ render x
 handleExpr _ (Op _     ) = error "erroneous syntax given to render"
--- handleExpr n (App (App (Op op@(ChainOp _)) p _) q _) = do
---   renderPrec n p <+> render op <+> renderPrec n q          -- chain operators are now handled with other binary operators
+handleExpr n (Chain ch ) = render ch
 handleExpr n (App (App (Op op) left _) right _) =  --binary operators
   parensIf n (Just op) $ 
   renderPrec (HOLEOp op) left 
@@ -100,6 +99,10 @@ handleExpr _ (ArrUpd e1 e2 e3 _) =
     -- SCM: need to print parenthesis around e1 when necessary.
 handleExpr _ (Case expr cases _) =
   "case" <+> render expr <+> "of" <+> vertE (map render cases)
+
+instance Render Chain where -- TODO: Check if this is correct.
+  render (Pure expr _) = render expr
+  render (More ch op expr _) = render ch <+> render op <+> render expr
 
 instance Render Mapping where
   render env | null env  = mempty

--- a/src/Render/Syntax/Common.hs
+++ b/src/Render/Syntax/Common.hs
@@ -47,6 +47,7 @@ instance Render ArithOp where
 
 instance Render TypeOp where
   render (Arrow l) = tempHandleLoc l $ render (show TokArrowU)
+
 instance Render Op where
   render (ChainOp op) = render op
   render (ArithOp op) = render op

--- a/src/Server/GoToDefn.hs
+++ b/src/Server/GoToDefn.hs
@@ -235,6 +235,7 @@ instance Collect LocationLinkToBe LocationLink Type where
     TTuple as    -> mapM_ collect as
     TFunc x y _  -> collect x >> collect y
     TApp  x y _  -> collect x >> collect y
+    TData {}     -> return () -- TODO:
     TVar _ _     -> return ()
     TMetaVar _   -> return ()
 

--- a/src/Server/GoToDefn.hs
+++ b/src/Server/GoToDefn.hs
@@ -234,7 +234,7 @@ instance Collect LocationLinkToBe LocationLink Type where
     TArray i x _ -> collect i >> collect x
     TTuple as    -> mapM_ collect as
     TFunc x y _  -> collect x >> collect y
-    TCon  x _ _  -> collect x
+    TApp  x y _  -> collect x >> collect y
     TVar _ _     -> return ()
     TMetaVar _   -> return ()
 

--- a/src/Server/GoToDefn.hs
+++ b/src/Server/GoToDefn.hs
@@ -113,6 +113,8 @@ scopeFromLocalBinders names =
 --------------------------------------------------------------------------------
 -- Names
 
+-- TODO: It is likely that the go-to-definition function for definitions is actually not yet implemented.
+-- Fixing this would be really good.
 instance Collect LocationLinkToBe LocationLink Name where
   collect name = do
     result <- lookupScopes (nameToText name)
@@ -216,7 +218,10 @@ instance Collect LocationLinkToBe LocationLink Expr where
 --     localScope args $ do
 --       collect body
 
-instance Collect LocationLinkToBe LocationLink Op where
+instance Collect LocationLinkToBe LocationLink ArithOp where
+  collect _ = return ()
+
+instance Collect LocationLinkToBe LocationLink ChainOp where
   collect _ = return ()
 
 instance Collect LocationLinkToBe LocationLink Chain where

--- a/src/Server/GoToDefn.hs
+++ b/src/Server/GoToDefn.hs
@@ -185,6 +185,7 @@ instance Collect LocationLinkToBe LocationLink Expr where
     Var   a _           -> collect a
     Const a _           -> collect a
     Op op               -> collect op
+    Chain ch            -> collect ch
     App  a b _          -> collect a >> collect b
     Lam  _ b _          -> collect b
     Func a b _          -> collect a >> collect b
@@ -217,6 +218,10 @@ instance Collect LocationLinkToBe LocationLink Expr where
 
 instance Collect LocationLinkToBe LocationLink Op where
   collect _ = return ()
+
+instance Collect LocationLinkToBe LocationLink Chain where
+  collect (Pure expr _) = collect expr
+  collect (More ch' op expr _) = collect ch' >> collect op >> collect expr
 
 instance Collect LocationLinkToBe LocationLink FuncClause where
   collect _ = return ()

--- a/src/Server/GoToDefn.hs
+++ b/src/Server/GoToDefn.hs
@@ -235,7 +235,7 @@ instance Collect LocationLinkToBe LocationLink Type where
     TTuple as    -> mapM_ collect as
     TFunc x y _  -> collect x >> collect y
     TApp  x y _  -> collect x >> collect y
-    TData {}     -> return () -- TODO:
+    TData n _ _  -> collect n
     TVar _ _     -> return ()
     TMetaVar _   -> return ()
 

--- a/src/Server/Highlighting.hs
+++ b/src/Server/Highlighting.hs
@@ -107,9 +107,8 @@ instance Collect () Highlighting Declaration where
     collect a
 
 instance Collect () Highlighting TypeDefnCtor where
-  collect (TypeDefnCtor name types) = do
+  collect (TypeDefnCtor name _) = do
     collect (AsName name)
-    collect types
 
 instance Collect () Highlighting DeclBase where
   collect (DeclBase as _ b) = do
@@ -273,4 +272,5 @@ instance Collect () Highlighting Type where
     collect b
   -- TODO: handle type application collect
   collect TApp{}      = return ()
+  collect TData{}     = return () -- TODO: Fix this.
   collect (TVar name) = addHighlighting J.SttType [] name

--- a/src/Server/Highlighting.hs
+++ b/src/Server/Highlighting.hs
@@ -271,6 +271,6 @@ instance Collect () Highlighting Type where
     collect a
     addHighlighting J.SttOperator [] tok
     collect b
-  -- TODO: handle user defined type collect
-  collect TCon{}      = return ()
+  -- TODO: handle type application collect
+  collect TApp{}      = return ()
   collect (TVar name) = addHighlighting J.SttType [] name

--- a/src/Server/Highlighting.hs
+++ b/src/Server/Highlighting.hs
@@ -196,6 +196,12 @@ instance Collect () Highlighting Expr where
     Var   a     -> collect (AsVariable a)
     Const a     -> collect (AsVariable a)
     Op    a     -> addHighlighting J.SttOperator [] a
+    Chain ch    -> case ch of
+      Pure expr -> collect expr
+      More ch' op expr -> do
+        collect (Chain ch')
+        addHighlighting J.SttOperator [] op
+        collect expr
     Arr a _ b _ -> do
       collect a
       collect b

--- a/src/Server/Highlighting.hs
+++ b/src/Server/Highlighting.hs
@@ -270,7 +270,8 @@ instance Collect () Highlighting Type where
     collect a
     addHighlighting J.SttOperator [] tok
     collect b
-  -- TODO: handle type application collect
-  collect TApp{}      = return ()
-  collect TData{}     = return () -- TODO: Fix this.
-  collect (TVar name) = addHighlighting J.SttType [] name
+  collect (TApp a b)  = do
+    collect a
+    collect b
+  collect (TData name) = addHighlighting J.SttType [] name
+  collect (TVar name)  = addHighlighting J.SttType [] name

--- a/src/Server/Hover.hs
+++ b/src/Server/Hover.hs
@@ -15,11 +15,9 @@ import           Data.Loc           ( Located
                                     , locOf
                                     )
 import           Data.Loc.Range
-import qualified GCL.Type           as TypeChecking
 import           Server.IntervalMap ( IntervalMap )
 import qualified Server.IntervalMap as IntervalMap
 import           Syntax.Abstract
-import           Syntax.Common
 import           Syntax.Typed                   as Typed
 
 collectHoverInfo :: Typed.TypedProgram -> IntervalMap (J.Hover, Type)
@@ -61,10 +59,10 @@ instance Collect Typed.TypedProgram where
 instance Collect Typed.TypedDefinition where
   collect (Typed.TypeDefn _ _ ctors _) = foldMap collect ctors
   collect (Typed.FuncDefnSig arg t prop _) = annotateType arg t <> maybe mempty collect prop
-  collect (Typed.FuncDefn name exprs) = foldMap collect exprs
+  collect (Typed.FuncDefn _name exprs) = foldMap collect exprs
 
 instance Collect Typed.TypedTypeDefnCtor where
-  collect (Typed.TypedTypeDefnCtor name tys) = mempty
+  collect (Typed.TypedTypeDefnCtor _name _tys) = mempty
 
 --------------------------------------------------------------------------------
 -- Declaration
@@ -79,7 +77,7 @@ instance Collect Typed.TypedDeclaration where
 instance Collect Typed.TypedStmt where
   collect (Typed.Skip _) = mempty
   collect (Typed.Abort _) = mempty
-  collect (Typed.Assign names exprs _) = foldMap collect exprs -- TODO: Display hover info for names.
+  collect (Typed.Assign _names exprs _) = foldMap collect exprs -- TODO: Display hover info for names.
   collect (Typed.AAssign arr index rhs _) = collect arr <> collect index <> collect rhs
   collect (Typed.Assert expr _) = collect expr
   collect (Typed.LoopInvariant inv bnd _) = collect inv <> collect bnd

--- a/src/Server/Hover.hs
+++ b/src/Server/Hover.hs
@@ -96,11 +96,16 @@ instance Collect Typed.TypedExpr where
   collect (Typed.Var name ty _) = annotateType name ty
   collect (Typed.Const name ty _) = annotateType name ty
   collect (Typed.Op op ty) = annotateType op ty
+  collect (Typed.Chain ch) = collect ch
   collect (Typed.App expr1 expr2 _) = collect expr1 <> collect expr2
   collect (Typed.Lam name ty expr _) = annotateType name ty <> collect expr
   collect (Typed.Quant quantifier _bound restriction inner _) = collect quantifier <> collect restriction <> collect inner
   collect (Typed.ArrIdx expr1 expr2 _) = collect expr1 <> collect expr2
   collect (Typed.ArrUpd arr index expr _) = collect arr <> collect index <> collect expr
+
+instance Collect Typed.TypedChain where
+  collect (Typed.Pure expr) = collect expr
+  collect (Typed.More chain op ty expr) = collect chain <> annotateType op ty <> collect expr
 
 {-
 

--- a/src/Server/Monad.hs
+++ b/src/Server/Monad.hs
@@ -55,7 +55,7 @@ import qualified Server.SrcLoc                 as SrcLoc
 import GCL.WP.Type (StructWarning)
 import Server.IntervalMap (IntervalMap)
 import Syntax.Abstract                         as A hiding ( Pure )
-import Syntax.Concrete                         as C
+import Syntax.Concrete                         as C hiding ( Pure )
 import GCL.Predicate (PO, Spec)
 import Data.IntMap (IntMap)
 

--- a/src/Server/Monad.hs
+++ b/src/Server/Monad.hs
@@ -54,7 +54,7 @@ import qualified Server.Pipeline               as DSL
 import qualified Server.SrcLoc                 as SrcLoc
 import GCL.WP.Type (StructWarning)
 import Server.IntervalMap (IntervalMap)
-import Syntax.Abstract                         as A
+import Syntax.Abstract                         as A hiding ( Pure )
 import Syntax.Concrete                         as C
 import GCL.Predicate (PO, Spec)
 import Data.IntMap (IntMap)

--- a/src/Syntax/Abstract/Instances/Json.hs
+++ b/src/Syntax/Abstract/Instances/Json.hs
@@ -10,12 +10,14 @@ instance ToJSON Interval
 instance ToJSON TBase
 instance ToJSON Type
 instance ToJSON Expr
+instance ToJSON Chain
 instance ToJSON FuncClause 
 instance ToJSON CaseClause
 instance ToJSON Pattern
 instance ToJSON Lit
 
 instance FromJSON Expr
+instance FromJSON Chain
 instance FromJSON FuncClause 
 instance FromJSON CaseClause
 instance FromJSON Pattern

--- a/src/Syntax/Abstract/Instances/Located.hs
+++ b/src/Syntax/Abstract/Instances/Located.hs
@@ -53,6 +53,7 @@ instance Located Type where
   locOf (TTuple _    ) = NoLoc
   locOf (TFunc _ _ l ) = l
   locOf (TApp  _ _ l ) = locOf l
+  locOf (TData _ _ l ) = l
   locOf (TVar _ l    ) = l
   locOf (TMetaVar _  ) = NoLoc
 

--- a/src/Syntax/Abstract/Instances/Located.hs
+++ b/src/Syntax/Abstract/Instances/Located.hs
@@ -52,7 +52,7 @@ instance Located Type where
   locOf (TArray _ _ l) = l
   locOf (TTuple _    ) = NoLoc
   locOf (TFunc _ _ l ) = l
-  locOf (TCon  _ _ l ) = locOf l
+  locOf (TApp  _ _ l ) = locOf l
   locOf (TVar _ l    ) = l
   locOf (TMetaVar _  ) = NoLoc
 

--- a/src/Syntax/Abstract/Instances/Located.hs
+++ b/src/Syntax/Abstract/Instances/Located.hs
@@ -62,6 +62,7 @@ instance Located Expr where
   locOf (Const _ l           ) = l
   locOf (Lit   _ l           ) = l
   locOf (Op op               ) = locOf op
+  locOf (Chain chain         ) = locOf chain
   locOf (App  _ _ l          ) = l
   locOf (Func _ _ l          ) = l
   locOf (Lam  _ _ l          ) = l
@@ -72,6 +73,10 @@ instance Located Expr where
   locOf (ArrIdx _ _ l        ) = l
   locOf (ArrUpd _ _ _ l      ) = l
   locOf (Case _ _ l          ) = l
+
+instance Located Chain where
+  locOf (Pure _ l            ) = l
+  locOf (More _ _ _ l        ) = l
 
 instance Located CaseClause where
   locOf (CaseClause l r) = l <--> r

--- a/src/Syntax/Abstract/Operator.hs
+++ b/src/Syntax/Abstract/Operator.hs
@@ -16,8 +16,8 @@ import           Prelude                 hiding ( Ordering(..) )
 unary :: ArithOp -> Expr -> Expr
 unary op x = App (Op op) x (x <--> op)
 
-binary :: ArithOp -> Expr -> Expr -> Expr
-binary op x y = App (App (Op op) x (x <--> op)) y (x <--> y)
+arith :: ArithOp -> Expr -> Expr -> Expr
+arith op x y = App (App (Op op) x (x <--> op)) y (x <--> y)
 
 chain :: ChainOp -> Expr -> Expr -> Expr -- TODO: This might be wrong. Needs further investigation.
 chain op x y = Chain (More (Pure x (x <--> op)) op y (x <--> y))
@@ -28,10 +28,10 @@ gt = (chain . GT) NoLoc
 gte = (chain . GTEU) NoLoc
 lte = (chain . LTEU) NoLoc
 eqq = (chain . EQ) NoLoc
-conj = (binary . ConjU) NoLoc
-disj = (binary . DisjU) NoLoc
-implies = (binary . ImpliesU) NoLoc
-add = (binary . Add) NoLoc
+conj = (arith . ConjU) NoLoc
+disj = (arith . DisjU) NoLoc
+implies = (arith . ImpliesU) NoLoc
+add = (arith . Add) NoLoc
 
 neg :: Expr -> Expr
 neg = (unary . NegU) NoLoc
@@ -75,9 +75,9 @@ forAll :: [Name] -> Expr -> Expr -> Expr
 forAll xs ran term = Quant (Op (ConjU NoLoc)) xs ran term NoLoc
 
 pointsTo, sConj, sImp :: Expr -> Expr -> Expr
-pointsTo = (binary . PointsTo) NoLoc
-sConj = (binary . SConj) NoLoc
-sImp = (binary . SImp) NoLoc
+pointsTo = (arith . PointsTo) NoLoc
+sConj = (arith . SConj) NoLoc
+sImp = (arith . SImp) NoLoc
 
 sconjunct :: [Expr] -> Expr
 sconjunct [] = true

--- a/src/Syntax/Abstract/Operator.hs
+++ b/src/Syntax/Abstract/Operator.hs
@@ -2,6 +2,7 @@ module Syntax.Abstract.Operator where
 
 import           Syntax.Abstract                ( Expr(..)
                                                 , Lit(..)
+                                                , Chain(..)
                                                 )
 import           Syntax.Common
 import           Data.Text                      ( Text )
@@ -13,13 +14,13 @@ import           Prelude                 hiding ( Ordering(..) )
 
 -- | Constructors
 unary :: ArithOp -> Expr -> Expr
-unary op x = App (Op (ArithOp op)) x (x <--> op)
+unary op x = App (Op op) x (x <--> op)
 
 binary :: ArithOp -> Expr -> Expr -> Expr
-binary op x y = App (App (Op (ArithOp op)) x (x <--> op)) y (x <--> y)
+binary op x y = App (App (Op op) x (x <--> op)) y (x <--> y)
 
-chain :: ChainOp -> Expr -> Expr -> Expr
-chain op x y = App (App (Op (ChainOp op)) x (x <--> op)) y (x <--> y)
+chain :: ChainOp -> Expr -> Expr -> Expr -- TODO: This might be wrong. Needs further investigation.
+chain op x y = Chain (More (Pure x (x <--> op)) op y (x <--> y))
 
 lt, gt, gte, lte, eqq, conj, disj, implies, add :: Expr -> Expr -> Expr
 lt = (chain . LT) NoLoc
@@ -50,7 +51,7 @@ disjunct [] = false
 disjunct xs = foldl1 disj xs
 
 imply :: Expr -> Expr -> Expr
-imply p q = App (App ((Op . ArithOp . ImpliesU) NoLoc) p (locOf p)) q (locOf q)
+imply p q = App (App ((Op . ImpliesU) NoLoc) p (locOf p)) q (locOf q)
 
 predEq :: Expr -> Expr -> Bool
 predEq = (==)
@@ -68,10 +69,10 @@ number :: Int -> Expr
 number n = Lit (Num n) NoLoc
 
 exists :: [Name] -> Expr -> Expr -> Expr
-exists xs ran term = Quant (Op (ArithOp (DisjU NoLoc))) xs ran term NoLoc
+exists xs ran term = Quant (Op (DisjU NoLoc)) xs ran term NoLoc
 
 forAll :: [Name] -> Expr -> Expr -> Expr
-forAll xs ran term = Quant (Op (ArithOp (ConjU NoLoc))) xs ran term NoLoc
+forAll xs ran term = Quant (Op (ConjU NoLoc)) xs ran term NoLoc
 
 pointsTo, sConj, sImp :: Expr -> Expr -> Expr
 pointsTo = (binary . PointsTo) NoLoc

--- a/src/Syntax/Abstract/Types.hs
+++ b/src/Syntax/Abstract/Types.hs
@@ -40,7 +40,7 @@ data Definition =
     deriving (Eq, Show)
 
 -- constructor of type definition
-data TypeDefnCtor = TypeDefnCtor Name [Type]
+data TypeDefnCtor = TypeDefnCtor Name [Name]
   deriving (Eq, Show)
 
 --------------------------------------------------------------------------------
@@ -100,6 +100,7 @@ data Type
   | TTuple [Type]
   | TFunc Type Type Loc
   | TApp Type Type Loc
+  | TData Name Int Loc
   | TVar Name Loc
   | TMetaVar Name
   deriving (Eq, Show, Generic)

--- a/src/Syntax/Abstract/Types.hs
+++ b/src/Syntax/Abstract/Types.hs
@@ -11,7 +11,8 @@ import           Data.Text                      ( Text )
 import           GHC.Generics                   ( Generic )
 import           Prelude                 hiding ( Ordering(..) )
 import           Syntax.Common                  ( Name
-                                                , Op
+                                                , ArithOp
+                                                , ChainOp
                                                 )
 --------------------------------------------------------------------------------
 
@@ -112,7 +113,7 @@ data Expr
   = Lit Lit Loc
   | Var Name Loc
   | Const Name Loc
-  | Op Op
+  | Op ArithOp
   | Chain Chain
   | App Expr Expr Loc
   | Lam Name Expr Loc
@@ -141,11 +142,11 @@ data Expr
   deriving (Eq, Show, Generic)
 
 
-data Chain = Pure Expr Loc | More Chain Op Expr Loc
+data Chain = Pure Expr Loc | More Chain ChainOp Expr Loc
   deriving (Eq, Show, Generic)
 
 -- QuantOp' seems not being used at current version of abstract?
-type QuantOp' = Either Op Expr
+type QuantOp' = Either ArithOp Expr
 
 type Mapping = Map Text Expr
 

--- a/src/Syntax/Abstract/Types.hs
+++ b/src/Syntax/Abstract/Types.hs
@@ -100,7 +100,7 @@ data Type
   | TTuple [Type]
   | TFunc Type Type Loc
   | TApp Type Type Loc
-  | TData Name Int Loc
+  | TData Name () {- TODO: kind system -} Loc
   | TVar Name Loc
   | TMetaVar Name
   deriving (Eq, Show, Generic)

--- a/src/Syntax/Abstract/Types.hs
+++ b/src/Syntax/Abstract/Types.hs
@@ -113,6 +113,7 @@ data Expr
   | Var Name Loc
   | Const Name Loc
   | Op Op
+  | Chain Chain
   | App Expr Expr Loc
   | Lam Name Expr Loc
   | Func Name (NonEmpty FuncClause) Loc
@@ -137,6 +138,10 @@ data Expr
   | ArrIdx Expr Expr Loc
   | ArrUpd Expr Expr Expr Loc
   | Case Expr [CaseClause] Loc
+  deriving (Eq, Show, Generic)
+
+
+data Chain = Pure Expr Loc | More Chain Op Expr Loc
   deriving (Eq, Show, Generic)
 
 -- QuantOp' seems not being used at current version of abstract?

--- a/src/Syntax/Abstract/Types.hs
+++ b/src/Syntax/Abstract/Types.hs
@@ -99,7 +99,7 @@ data Type
   -- TTuple has no srcloc info because it has no conrete syntax at the moment 
   | TTuple [Type]
   | TFunc Type Type Loc
-  | TCon Name [Name] Loc
+  | TApp Type Type Loc
   | TVar Name Loc
   | TMetaVar Name
   deriving (Eq, Show, Generic)

--- a/src/Syntax/Abstract/Util.hs
+++ b/src/Syntax/Abstract/Util.hs
@@ -29,10 +29,10 @@ import           Syntax.Common                  ( Name(..)
     --Nothing
     --(locOf cn)
 
-wrapTFunc :: [Type] -> Type -> Type
+wrapTFunc :: [Name] -> Type -> Type
 wrapTFunc []       t  = t
-wrapTFunc [t     ] t0 = TFunc t t0 (locOf t)
-wrapTFunc (t : ts) t0 = let t0' = wrapTFunc ts t0 in TFunc t t0' (t <--> t0')
+wrapTFunc [t     ] t0 = TFunc (TMetaVar t) t0 (locOf t)
+wrapTFunc (t : ts) t0 = let t0' = wrapTFunc ts t0 in TFunc (TMetaVar t) t0' (t <--> t0')
 
 getGuards :: [GdCmd] -> [Expr]
 getGuards = fst . unzipGdCmds

--- a/src/Syntax/Common/Types.hs
+++ b/src/Syntax/Common/Types.hs
@@ -132,7 +132,7 @@ precedenceOrder =
     , (ChainOp (EQPropU NoLoc), InfixL)
     ]
   -- Below is a type operator and is naturally very different from other operators.
-  -- It is put it here because we need a way to know its fixity.
+  -- It is put here because we need a way to know its fixity.
   , [ (TypeOp (Arrow NoLoc), InfixR) ]
   ]
 

--- a/src/Syntax/Concrete/Instances/Located.hs
+++ b/src/Syntax/Concrete/Instances/Located.hs
@@ -82,7 +82,7 @@ instance Located Type where
   locOf (TBase a       ) = locOf a
   locOf (TArray l _ _ r) = l <--> r
   locOf (TFunc l _ r   ) = l <--> r
-  locOf (TCon l r      ) = l <--> r
+  locOf (TApp l r      ) = l <--> r
   locOf (TVar x        ) = locOf x
 
 --------------------------------------------------------------------------------

--- a/src/Syntax/Concrete/Instances/Located.hs
+++ b/src/Syntax/Concrete/Instances/Located.hs
@@ -94,10 +94,15 @@ instance Located Expr where
   locOf (Var   x              ) = locOf x
   locOf (Const x              ) = locOf x
   locOf (Op    x              ) = locOf x
+  locOf (Chain ch             ) = locOf ch
   locOf (Arr l _ _ r          ) = l <--> r
   locOf (App x y              ) = x <--> y
   locOf (Quant l _ _ _ _ _ _ r) = l <--> r
   locOf (Case l _ _ r         ) = l <--> r
+
+instance Located Chain where
+  locOf (Pure expr) = locOf expr
+  locOf (More ch _ expr) = ch <--> expr
 
 instance Located CaseClause where
   locOf (CaseClause l _ r) = l <--> r

--- a/src/Syntax/Concrete/Instances/Located.hs
+++ b/src/Syntax/Concrete/Instances/Located.hs
@@ -83,6 +83,7 @@ instance Located Type where
   locOf (TArray l _ _ r) = l <--> r
   locOf (TFunc l _ r   ) = l <--> r
   locOf (TApp l r      ) = l <--> r
+  locOf (TData name    ) = locOf name
   locOf (TVar x        ) = locOf x
 
 --------------------------------------------------------------------------------

--- a/src/Syntax/Concrete/Instances/ToAbstract.hs
+++ b/src/Syntax/Concrete/Instances/ToAbstract.hs
@@ -90,7 +90,7 @@ instance ToAbstract Definition [A.Definition] where
     return [A.FuncDefn name [wrapLam args body']]
 
 instance ToAbstract TypeDefnCtor A.TypeDefnCtor where
-  toAbstract (TypeDefnCtor c ts) = A.TypeDefnCtor c <$> toAbstract ts
+  toAbstract (TypeDefnCtor c ts) = return $ A.TypeDefnCtor c ts
 
 --------------------------------------------------------------------------------
 -- | Declaraion
@@ -192,6 +192,7 @@ instance ToAbstract Type A.Type where
       A.TFunc <$> toAbstract a <*> toAbstract b <*> pure (locOf t)
     (TApp l r) -> A.TApp <$> toAbstract l <*> toAbstract r <*> pure (l <--> r)
     (TVar a      ) -> pure $ A.TVar a (locOf t)
+    (TData n     ) -> pure $ A.TData n 1 (locOf t) -- FIXME: Do not limit the parameter count to 1.
     (TParen _ a _) -> do
       t' <- toAbstract a
       case t' of
@@ -200,6 +201,7 @@ instance ToAbstract Type A.Type where
         A.TTuple as'     -> pure $ A.TTuple as'
         A.TFunc a' b' _  -> pure $ A.TFunc a' b' (locOf t)
         A.TApp  a' b' _  -> pure $ A.TApp a' b' (locOf t)
+        A.TData name i _ -> pure $ A.TData name i (locOf t)
         A.TVar a' _      -> pure $ A.TVar a' (locOf t)
         A.TMetaVar a'    -> pure $ A.TMetaVar a'
 

--- a/src/Syntax/Concrete/Instances/ToAbstract.hs
+++ b/src/Syntax/Concrete/Instances/ToAbstract.hs
@@ -215,6 +215,7 @@ instance ToAbstract Expr A.Expr where
     Var   a     -> pure $ A.Var a (locOf x)
     Const a     -> pure $ A.Const a (locOf x)
     Op    a     -> pure $ A.Op a
+    Chain ch    -> A.Chain <$> toAbstract ch
     Arr arr _ i _ ->
       A.ArrIdx <$> toAbstract arr <*> toAbstract i <*> pure (locOf x)
     App a b -> A.App <$> toAbstract a <*> toAbstract b <*> pure (locOf x)
@@ -231,6 +232,11 @@ instance ToAbstract Expr A.Expr where
         Right n@(Name _ l) -> return $ A.Const n l
     Case _ expr _ cases ->
       A.Case <$> toAbstract expr <*> toAbstract cases <*> pure (locOf x)
+
+instance ToAbstract Chain A.Chain where
+  toAbstract chain = case chain of
+    Pure expr -> A.Pure <$> toAbstract expr <*> pure (locOf expr)
+    More ch' op expr -> A.More <$> toAbstract ch' <*> pure op <*> toAbstract expr <*> pure (locOf expr)
 
 instance ToAbstract CaseClause A.CaseClause where
   toAbstract (CaseClause patt _ body) =

--- a/src/Syntax/Concrete/Instances/ToAbstract.hs
+++ b/src/Syntax/Concrete/Instances/ToAbstract.hs
@@ -190,11 +190,7 @@ instance ToAbstract Type A.Type where
       A.TArray <$> toAbstract a <*> toAbstract b <*> pure (locOf t)
     (TFunc a _ b) ->
       A.TFunc <$> toAbstract a <*> toAbstract b <*> pure (locOf t)
-    (TCon n@(Name tn l) ns    ) 
-      | tn == "Int"  && null ns -> return $ A.TBase A.TInt l
-      | tn == "Bool" && null ns -> return $ A.TBase A.TBool l
-      | tn == "Char" && null ns -> return $ A.TBase A.TChar l
-      | otherwise -> return $ A.TCon n ns (n <--> ns)
+    (TApp l r) -> A.TApp <$> toAbstract l <*> toAbstract r <*> pure (l <--> r)
     (TVar a      ) -> pure $ A.TVar a (locOf t)
     (TParen _ a _) -> do
       t' <- toAbstract a
@@ -203,7 +199,7 @@ instance ToAbstract Type A.Type where
         A.TArray a' b' _ -> pure $ A.TArray a' b' (locOf t)
         A.TTuple as'     -> pure $ A.TTuple as'
         A.TFunc a' b' _  -> pure $ A.TFunc a' b' (locOf t)
-        A.TCon  a' b' _  -> pure $ A.TCon a' b' (locOf t)
+        A.TApp  a' b' _  -> pure $ A.TApp a' b' (locOf t)
         A.TVar a' _      -> pure $ A.TVar a' (locOf t)
         A.TMetaVar a'    -> pure $ A.TMetaVar a'
 

--- a/src/Syntax/Concrete/Instances/ToAbstract.hs
+++ b/src/Syntax/Concrete/Instances/ToAbstract.hs
@@ -192,7 +192,7 @@ instance ToAbstract Type A.Type where
       A.TFunc <$> toAbstract a <*> toAbstract b <*> pure (locOf t)
     (TApp l r) -> A.TApp <$> toAbstract l <*> toAbstract r <*> pure (l <--> r)
     (TVar a      ) -> pure $ A.TVar a (locOf t)
-    (TData n     ) -> pure $ A.TData n 1 (locOf t) -- FIXME: Do not limit the parameter count to 1.
+    (TData n     ) -> pure $ A.TData n () (locOf t)
     (TParen _ a _) -> do
       t' <- toAbstract a
       case t' of

--- a/src/Syntax/Concrete/Types.hs
+++ b/src/Syntax/Concrete/Types.hs
@@ -67,7 +67,7 @@ data Definition
   | FuncDefn Name [Name] (Token "=") Expr
   deriving (Eq, Show)
 
-data TypeDefnCtor = TypeDefnCtor Name [Type] deriving (Eq, Show)
+data TypeDefnCtor = TypeDefnCtor Name [Name] deriving (Eq, Show)
 
 --------------------------------------------------------------------------------
 -- | Declaration
@@ -141,6 +141,7 @@ data Type
   | TArray (Token "array") Interval (Token "of") Type
   | TFunc Type TokArrows Type
   | TApp Type Type
+  | TData Name -- TODO: add range
   | TVar Name
   deriving (Eq, Show)
 

--- a/src/Syntax/Concrete/Types.hs
+++ b/src/Syntax/Concrete/Types.hs
@@ -140,7 +140,7 @@ data Type
   | TBase TBase
   | TArray (Token "array") Interval (Token "of") Type
   | TFunc Type TokArrows Type
-  | TCon Name [Name]
+  | TApp Type Type
   | TVar Name
   deriving (Eq, Show)
 

--- a/src/Syntax/Concrete/Types.hs
+++ b/src/Syntax/Concrete/Types.hs
@@ -15,6 +15,7 @@ import Syntax.Common (Name, Op)
 import Prelude hiding (Ordering (..))
 import Data.Loc (Located (locOf), Pos, Loc (Loc), L)
 import Syntax.Parser.Lexer (Tok)
+import Render.Class (Render (..))
 
 --------------------------------------------------------------------------------
 
@@ -154,6 +155,7 @@ data Expr
   | Var Name
   | Const Name
   | Op Op
+  | Chain Chain
   | Arr Expr (Token "[") Expr (Token "]")
   | App Expr Expr
   | Quant
@@ -167,6 +169,9 @@ data Expr
       TokQuantEnds
   -- case expr of { ctor1 -> expr | ctor2 binder1 binder2 -> expr }
   | Case (Token "case") Expr (Token "of") [CaseClause]
+  deriving (Eq, Show, Generic)
+
+data Chain = Pure Expr | More Chain Op Expr
   deriving (Eq, Show, Generic)
 
 type QuantOp' = Either Op Name

--- a/src/Syntax/Concrete/Types.hs
+++ b/src/Syntax/Concrete/Types.hs
@@ -11,7 +11,7 @@ import Data.Loc.Range
 import Data.Text (Text)
 import GHC.Base (Symbol)
 import GHC.Generics (Generic)
-import Syntax.Common (Name, Op)
+import Syntax.Common (Name, ArithOp, ChainOp)
 import Prelude hiding (Ordering (..))
 import Data.Loc (Located (locOf), Pos, Loc (Loc), L)
 import Syntax.Parser.Lexer (Tok)
@@ -154,7 +154,7 @@ data Expr
   | Lit Lit
   | Var Name
   | Const Name
-  | Op Op
+  | Op ArithOp
   | Chain Chain
   | Arr Expr (Token "[") Expr (Token "]")
   | App Expr Expr
@@ -171,10 +171,10 @@ data Expr
   | Case (Token "case") Expr (Token "of") [CaseClause]
   deriving (Eq, Show, Generic)
 
-data Chain = Pure Expr | More Chain Op Expr
+data Chain = Pure Expr | More Chain ChainOp Expr
   deriving (Eq, Show, Generic)
 
-type QuantOp' = Either Op Name
+type QuantOp' = Either ArithOp Name
 
 --------------------------------------------------------------------------------
 -- | Pattern matching

--- a/src/Syntax/Parser.hs
+++ b/src/Syntax/Parser.hs
@@ -644,7 +644,7 @@ type' = do
   makeExprParser term table <?> "type"
  where
   table :: [[Operator Parser Type]]
-  table = [[InfixR function]]
+  table = [[InfixL (return TApp)], [InfixR function]]
 
   function :: Parser (Type -> Type -> Type)
   function = do
@@ -652,17 +652,13 @@ type' = do
     return $ \x y -> TFunc x arrow y
 
   term :: Parser Type
-  term = parensType <|> array <|> try typeVar <|> typeName <?> "type term"
+  term = parensType <|> array <|> typeVar <?> "type term"
 
   parensType :: Parser Type
   parensType = TParen <$> tokenParenOpen <*> type' <*> tokenParenClose
 
-
   typeVar :: Parser Type
-  typeVar = TVar <$> lower
-
-  typeName :: Parser Type
-  typeName = TApp <$> (TVar <$> identifier) <*> (TVar <$> identifier) -- TODO: This does not work well.
+  typeVar = TVar <$> identifier
 
   array :: Parser Type
   array = TArray <$> tokenArray <*> interval <*> tokenOf <*> type'

--- a/src/Syntax/Parser.hs
+++ b/src/Syntax/Parser.hs
@@ -662,7 +662,7 @@ type' = do
   typeVar = TVar <$> lower
 
   typeName :: Parser Type
-  typeName = TCon <$> upper <*> many lower
+  typeName = TApp <$> (TVar <$> identifier) <*> (TVar <$> identifier) -- TODO: This does not work well.
 
   array :: Parser Type
   array = TArray <$> tokenArray <*> interval <*> tokenOf <*> type'

--- a/src/Syntax/Parser.hs
+++ b/src/Syntax/Parser.hs
@@ -528,7 +528,11 @@ expression = do
   chainOp :: (Loc -> Op) -> Tok -> Parser (Expr -> Expr -> Expr) -- FIXME:
   chainOp operator' tok = do
     (op, loc) <- getLoc (operator' <$ symbol tok)
-    return $ \x y -> App (App (Expr.Op (op loc)) x) y
+    return (`makeChain` op loc)
+    where
+      makeChain a op b = Chain $ More (asChain a) op b
+      asChain (Chain c) = c
+      asChain e = Pure e
 
   parensExpr :: Parser Expr
   parensExpr = Paren <$> tokenParenOpen <*> expression <*> tokenParenClose

--- a/src/Syntax/Parser/Lexer.hs
+++ b/src/Syntax/Parser/Lexer.hs
@@ -88,7 +88,10 @@ data Tok
   | TokDeclClose
   | -- expression
     TokUnderscore
-
+    -- types
+  | TokIntType
+  | TokBoolType
+  | TokCharType
     -- operators
   | TokEQ
   | TokNEQ
@@ -132,7 +135,7 @@ data Tok
   | TokChar Char
   | TokTrue
   | TokFalse
-  
+
   -- tokens for proof block {- #anchor ...} or block comment {- ... -}
   | TokProof String String String -- anchor, contents, full-text containing "{-", "-}"
   deriving (Eq, Ord)
@@ -224,6 +227,9 @@ instance Show Tok where
     TokChar      c       -> "'" <> show c <> "'"
     TokTrue              -> "True"
     TokFalse             -> "False"
+    TokIntType           -> "Int"
+    TokBoolType          -> "Bool"
+    TokCharType          -> "Char"
     TokProof s _ _       -> "{- #" ++ s ++ " ...-}"
 
 type TokStream = TokenStream (L Tok)
@@ -391,6 +397,12 @@ tokRE =
     <$  string "True"
     <|> TokFalse
     <$  string "False"
+    <|> TokIntType
+    <$  string "Int"
+    <|> TokBoolType
+    <$  string "Bool"
+    <|> TokCharType
+    <$  string "Char"
     <|> TokUpperName
     .   Text.pack
     <$> upperNameRE

--- a/src/Syntax/Substitution.hs
+++ b/src/Syntax/Substitution.hs
@@ -38,6 +38,7 @@ instance Fresh m => Substitutable m Expr Expr where
   subst sb (Const x l) =
     return . maybe (Var x l) id $ lookup (nameToText x) sb
   subst _ e@(Op _) = return e
+  subst sb (Chain ch) = Chain <$> subst sb ch
   subst sb (App e1 e2 l) =
     App <$> subst sb e1 <*> subst sb e2 <*> pure l
   subst sb (Lam x e l)
@@ -62,6 +63,9 @@ instance Fresh m => Substitutable m Expr Expr where
       $ \(CaseClause patt body) -> CaseClause patt <$> subst sb body
     return $ Case e cases' l
 
+instance Fresh m => Substitutable m Chain Expr where
+  subst sb (Pure expr loc) = Pure <$> subst sb expr <*> pure loc
+  subst sb (More ch' op expr loc) = More <$> subst sb ch' <*> pure op <*> subst sb expr <*> pure loc
 
 instance Fresh m => Substitutable m FuncClause Expr where
   subst _ = return

--- a/src/Syntax/Typed.hs
+++ b/src/Syntax/Typed.hs
@@ -49,6 +49,7 @@ data TypedExpr
   | Var Name Type Loc
   | Const Name Type Loc
   | Op Op Type
+  | Chain TypedChain
   | App TypedExpr TypedExpr Loc
   | Lam Name Type TypedExpr Loc
   | Quant TypedExpr [Name] TypedExpr TypedExpr Loc
@@ -56,3 +57,8 @@ data TypedExpr
   | ArrUpd TypedExpr TypedExpr TypedExpr Loc
   deriving (Eq, Show)
   -- FIXME: Other constructors.
+
+data TypedChain
+  = Pure TypedExpr
+  | More TypedChain Op Type TypedExpr
+  deriving (Eq, Show)

--- a/src/Syntax/Typed.hs
+++ b/src/Syntax/Typed.hs
@@ -19,7 +19,7 @@ data TypedDefinition
   | FuncDefn Name [TypedExpr]
   deriving (Eq, Show)
 
-data TypedTypeDefnCtor = TypedTypeDefnCtor Name [Type]
+data TypedTypeDefnCtor = TypedTypeDefnCtor Name [Name]
   deriving (Eq, Show)
 
 data TypedDeclaration


### PR DESCRIPTION
This PR (re-)implement `Chain` as a data type to represent chained operators.
Furthermore, it ditches some usages of `Op` in favor of the more specific `ArithOp` & `ChainOp`.