### PR TITLE
[refactor] Changed names for data in Syntax.Typed.

### DIFF
--- a/src/Server/Handler/Guabao/Refine.hs
+++ b/src/Server/Handler/Guabao/Refine.hs
@@ -54,7 +54,7 @@ instance JSON.ToJSON RefineResult
 -- TODO customize refine error
 type RefineError = Error
 
--- assumes specText is surrounded by "[!" and "!]" 
+-- assumes specText is surrounded by "[!" and "!]"
 handler :: RefineParams -> (RefineResult -> ServerM ()) -> (RefineError -> ServerM ()) -> ServerM ()
 handler _params@RefineParams{filePath, specRange, specText} onSuccess onError = do
   -- 把上次 load 的資料拿出來
@@ -109,7 +109,7 @@ handler _params@RefineParams{filePath, specRange, specText} onSuccess onError = 
 
 
 
--- assumes specText is surrounded by "[!" and "!]" 
+-- assumes specText is surrounded by "[!" and "!]"
 trimSpecBracketsAndSpaces :: Text -> Text
 trimSpecBracketsAndSpaces specText
   = Text.strip $ Text.dropEnd 2 $ Text.drop 2 specText
@@ -200,7 +200,7 @@ parseFragment fragmentStart fragment = do
     translateTokStream _ (TsError e) = TsError e
 
 toAbstractFragment :: [C.Stmt] -> Maybe [A.Stmt]
-toAbstractFragment concreteFragment = 
+toAbstractFragment concreteFragment =
   case runExcept $ C.toAbstract concreteFragment of
     Left _                 -> Nothing
     Right abstractFragment -> Just abstractFragment
@@ -229,6 +229,5 @@ instance Elab [A.Stmt] where
 --   }
 --   deriving (Eq, Show, Generic)
 
-sweepFragment :: Int -> Spec -> [T.TypedStmt] -> Either StructError ([PO], [Spec], [StructWarning])
+sweepFragment :: Int -> Spec -> [T.Stmt] -> Either StructError ([PO], [Spec], [StructWarning])
 sweepFragment specIdStart spec impl = error "TODO: define this after modifying definitions of Spec and StructStmts"
-

--- a/src/Server/Hover.hs
+++ b/src/Server/Hover.hs
@@ -20,7 +20,7 @@ import qualified Server.IntervalMap as IntervalMap
 import           Syntax.Abstract
 import           Syntax.Typed                   as Typed
 
-collectHoverInfo :: Typed.TypedProgram -> IntervalMap (J.Hover, Type)
+collectHoverInfo :: Typed.Program -> IntervalMap (J.Hover, Type)
 collectHoverInfo = collect
 
 instance Pretty J.Hover where
@@ -50,31 +50,31 @@ instance Collect a => Collect [a] where
 --------------------------------------------------------------------------------
 -- Program
 
-instance Collect Typed.TypedProgram where
+instance Collect Typed.Program where
   collect (Typed.Program defns decls exprs stmts _) = foldMap collect defns <> foldMap collect decls <> foldMap collect exprs <> foldMap collect stmts
 
 --------------------------------------------------------------------------------
 -- Definition
 
-instance Collect Typed.TypedDefinition where
+instance Collect Typed.Definition where
   collect (Typed.TypeDefn _ _ ctors _) = foldMap collect ctors
   collect (Typed.FuncDefnSig arg t prop _) = annotateType arg t <> maybe mempty collect prop
   collect (Typed.FuncDefn _name expr) = collect expr
 
-instance Collect Typed.TypedTypeDefnCtor where
-  collect (Typed.TypedTypeDefnCtor _name _tys) = mempty
+instance Collect Typed.TypeDefnCtor where
+  collect (Typed.TypeDefnCtor _name _tys) = mempty
 
 --------------------------------------------------------------------------------
 -- Declaration
 
-instance Collect Typed.TypedDeclaration where
+instance Collect Typed.Declaration where
   collect (Typed.ConstDecl names ty expr _) = annotateType names ty <> maybe mempty collect expr
   collect (Typed.VarDecl names ty expr _) = annotateType names ty <> maybe mempty collect expr
 
 --------------------------------------------------------------------------------
 -- Stmt
 
-instance Collect Typed.TypedStmt where -- TODO: Display hover info for names.
+instance Collect Typed.Stmt where -- TODO: Display hover info for names.
   collect (Typed.Skip _) = mempty
   collect (Typed.Abort _) = mempty
   collect (Typed.Assign _names exprs _) = foldMap collect exprs
@@ -89,14 +89,14 @@ instance Collect Typed.TypedStmt where -- TODO: Display hover info for names.
   collect (Typed.HLookup _name expr _) = collect expr
   collect (Typed.HMutate e1 e2 _) = collect e1 <> collect e2
   collect (Typed.Dispose expr _) = collect expr
-  collect (Typed.Block program _) = collect program 
+  collect (Typed.Block program _) = collect program
 
-instance Collect Typed.TypedGdCmd where
-  collect (Typed.TypedGdCmd gd stmts _) = collect gd <> foldMap collect stmts
+instance Collect Typed.GdCmd where
+  collect (Typed.GdCmd gd stmts _) = collect gd <> foldMap collect stmts
 
 --------------------------------------------------------------------------------
 
-instance Collect Typed.TypedExpr where
+instance Collect Typed.Expr where
   collect (Typed.Lit _lit ty loc) = annotateType loc ty
   collect (Typed.Var name ty _) = annotateType name ty
   collect (Typed.Const name ty _) = annotateType name ty
@@ -108,7 +108,7 @@ instance Collect Typed.TypedExpr where
   collect (Typed.ArrIdx expr1 expr2 _) = collect expr1 <> collect expr2
   collect (Typed.ArrUpd arr index expr _) = collect arr <> collect index <> collect expr
 
-instance Collect Typed.TypedChain where
+instance Collect Typed.Chain where
   collect (Typed.Pure expr) = collect expr
   collect (Typed.More chain op ty expr) = collect chain <> annotateType op ty <> collect expr
 

--- a/src/Server/Load.hs
+++ b/src/Server/Load.hs
@@ -103,11 +103,11 @@ collectHoles (C.Program _ statements) = do
     C.SpecQM range -> return range
     _ -> []
 
-elaborate :: A.Program -> Either Error T.TypedProgram
+elaborate :: A.Program -> Either Error T.Program
 elaborate abstract = do
   case TypeChecking.runElaboration abstract mempty of
     Left  e -> Left (TypeError e)
     Right typedProgram -> return typedProgram
 
-sweepElaborated :: T.TypedProgram -> Either StructError ([PO], [Spec], [StructWarning])
+sweepElaborated :: T.Program -> Either StructError ([PO], [Spec], [StructWarning])
 sweepElaborated elaborated = error "TODO"

--- a/src/Server/Monad.hs
+++ b/src/Server/Monad.hs
@@ -64,7 +64,7 @@ data FileState = FileState
   , variableCounter  :: Int
   , definitionLinks  :: IntervalMap LSP.LocationLink
   , hoverInfos       :: IntervalMap (LSP.Hover, Abstract.Type)
-  , elaborated       :: Typed.TypedProgram
+  , elaborated       :: Typed.Program
   , positionDelta    :: PositionDelta   -- loadedVersion ~> editedVersion
   , editedVersion    :: Int  -- the version number of the last change
   }
@@ -84,7 +84,7 @@ runServerM :: GlobalState -> LSP.LanguageContextEnv () -> ServerM a -> IO a
 runServerM globalState ctxEnv program = runReaderT (LSP.runLspT ctxEnv program) globalState
 
 --------------------------------------------------------------------------------
--- | Helper functions for side effects 
+-- | Helper functions for side effects
 
 -- display Text
 logText :: Text -> ServerM ()
@@ -203,7 +203,7 @@ digHoles filePath ranges onFinish = do
 --   let responses =
 --         [ResDisplay version (map renderSection errors), ResUpdateSpecs []]
 
---   -- collect Diagnostics from [Error] 
+--   -- collect Diagnostics from [Error]
 --   let diagnostics = errors >>= collect
 
 --   return (responses, diagnostics)
@@ -261,7 +261,7 @@ digHoles filePath ranges onFinish = do
 --       <> toText (length diagnosticsFromError)
 --       <> " diagnostics"
 
---     -- send diagnostics 
+--     -- send diagnostics
 --     sendDiagnosticsLSP filepath diagnosticsFromError
 --     -- send responses
 --     J.sendNotification (J.SCustomMethod "guabao") $ JSON.toJSON $ Res

--- a/src/Syntax/Abstract/Types.hs
+++ b/src/Syntax/Abstract/Types.hs
@@ -97,7 +97,7 @@ data TBase = TInt | TBool | TChar
 data Type
   = TBase TBase Loc
   | TArray Interval Type Loc
-  -- TTuple has no srcloc info because it has no conrete syntax at the moment 
+  -- TTuple has no srcloc info because it has no conrete syntax at the moment
   | TTuple [Type]
   | TFunc Type Type Loc
   | TApp Type Type Loc
@@ -118,10 +118,10 @@ data Expr
   | App Expr Expr Loc
   | Lam Name Expr Loc
   | Func Name (NonEmpty FuncClause) Loc
-  -- Tuple has no srcloc info because it has no conrete syntax at the moment 
+  -- Tuple has no srcloc info because it has no conrete syntax at the moment
   | Tuple [Expr]
   | Quant Expr [Name] Expr Expr Loc
-  -- The innermost part of a Redex 
+  -- The innermost part of a Redex
   -- should look something like `P [ x \ a ] [ y \ b ]`
   | RedexKernel
     Name -- the variable to be substituted
@@ -129,12 +129,12 @@ data Expr
     (Set Name) -- free variables in that expression
                -- NOTE, the expression may be some definition like "P",
               --  in that case, the free variables should be that of after it's been expanded
-    (NonEmpty Mapping) 
+    (NonEmpty Mapping)
       -- a list of mappings of substitutions to be displayed to users (the `[ x \ a ] [ y \ b ]` part)
       -- The order is reflected.
   -- The outermost part of a Redex
   | RedexShell
-      Int -- for identifying Redexes in frontend-backend interactions 
+      Int -- for identifying Redexes in frontend-backend interactions
       Expr -- should either be `RedexKernel` or `App (App (App ... RedexKernel arg0) ... argn`
   | ArrIdx Expr Expr Loc
   | ArrUpd Expr Expr Expr Loc
@@ -153,11 +153,11 @@ type Mapping = Map Text Expr
 --------------------------------------------------------------------------------
 -- | Pattern matching
 
--- pattern -> expr 
+-- pattern -> expr
 data CaseClause = CaseClause Pattern Expr
   deriving (Eq, Show, Generic)
 
--- pattern0 pattern1 pattern2 ... -> expr 
+-- pattern0 pattern1 pattern2 ... -> expr
 data FuncClause = FuncClause [Pattern] Expr
   deriving (Eq, Show, Generic)
 
@@ -174,10 +174,11 @@ extractBinder (PattBinder   x      ) = [x]
 extractBinder (PattWildcard _      ) = []
 extractBinder (PattConstructor _ xs) = xs >>= extractBinder
 
+
 ----------------------------------------------------------------
 
 -- | Literals
 data Lit = Num Int | Bol Bool | Chr Char | Emp
   deriving (Show, Eq, Generic)
-
+  
 ----------------------------------------------------------------

--- a/src/Syntax/Common/Types.hs
+++ b/src/Syntax/Common/Types.hs
@@ -141,7 +141,7 @@ initOrderIndex = 1
 
 classificationMap :: Map Op (Fixity,Int)
 classificationMap = Map.fromList $ concat $ zipWith f [initOrderIndex..] precedenceOrder
-  where 
+  where
     f :: Int -> [(Op,Fixity)] -> [(Op,(Fixity,Int))]
     f n = map (second (,n))
 
@@ -176,9 +176,9 @@ classificationMap = Map.fromList $ concat $ zipWith f [initOrderIndex..] precede
 -- classifyArithOp (Max      _) = InfixL 4
 -- classifyArithOp (Min      _) = InfixL 4
 
--- classifyArithOp (PointsTo _) = Infix 5 
--- classifyArithOp (SConj    _) = InfixL 6 
--- classifyArithOp (SImp     _) = Infix 7  
+-- classifyArithOp (PointsTo _) = Infix 5
+-- classifyArithOp (SConj    _) = InfixL 6
+-- classifyArithOp (SImp     _) = Infix 7
 
 -- classifyArithOp (Disj     _) = InfixL 9
 -- classifyArithOp (DisjU    _) = InfixL 9
@@ -190,7 +190,7 @@ classificationMap = Map.fromList $ concat $ zipWith f [initOrderIndex..] precede
 
 
 classify :: Op -> (Fixity,Int)
-classify op = fromMaybe (error "Operator's precedenceOrder is not completely defined.") 
+classify op = fromMaybe (error "Operator's precedenceOrder is not completely defined.")
               $ Map.lookup (wipeLoc op) classificationMap
 
 precOf :: Op -> Int
@@ -246,7 +246,7 @@ wipeLoc op = case op of
 isAssocOp :: Op -> Bool
 isAssocOp (ArithOp (Mul _)) = True
 isAssocOp (ArithOp (Add _)) = True
-isAssocOp (ArithOp (Conj _))  = True 
+isAssocOp (ArithOp (Conj _))  = True
 isAssocOp (ArithOp (ConjU _)) = True
 isAssocOp (ArithOp (Disj _))  = True
 isAssocOp (ArithOp (DisjU _)) = True

--- a/src/Syntax/Typed.hs
+++ b/src/Syntax/Typed.hs
@@ -1,4 +1,7 @@
-module Syntax.Typed where
+module Syntax.Typed (
+  module Syntax.Typed,
+  Lit, Type
+  ) where
 
 import Data.Text ( Text )
 import Data.Loc ( Loc )
@@ -7,63 +10,63 @@ import Syntax.Abstract.Types ( Lit, Type )
 import Syntax.Common.Types ( Name, Op )
 import GCL.Common ( TypeEnv )
 
-data TypedProgram = Program [TypedDefinition] -- definitions (the functional language part)
-                            [TypedDeclaration] -- constant and variable declarations
-                            [TypedExpr] -- global properties
-                            [TypedStmt] -- main program
-                            Loc
+data Program = Program [Definition] -- definitions (the functional language part)
+                       [Declaration] -- constant and variable declarations
+                       [Expr] -- global properties
+                       [Stmt] -- main program
+                       Loc
   deriving (Eq, Show)
 
-data TypedDefinition
-  = TypeDefn Name [Name] [TypedTypeDefnCtor] Loc
-  | FuncDefnSig Name Type (Maybe TypedExpr) Loc
-  | FuncDefn Name TypedExpr
+data Definition
+  = TypeDefn Name [Name] [TypeDefnCtor] Loc
+  | FuncDefnSig Name Type (Maybe Expr) Loc
+  | FuncDefn Name Expr
   deriving (Eq, Show)
 
-data TypedTypeDefnCtor = TypedTypeDefnCtor Name [Name]
+data TypeDefnCtor = TypeDefnCtor Name [Name]
   deriving (Eq, Show)
 
-data TypedDeclaration
-  = ConstDecl [Name] Type (Maybe TypedExpr) Loc
-  | VarDecl [Name] Type (Maybe TypedExpr) Loc
+data Declaration
+  = ConstDecl [Name] Type (Maybe Expr) Loc
+  | VarDecl [Name] Type (Maybe Expr) Loc
   deriving (Eq, Show)
 
-data TypedStmt
+data Stmt
   = Skip Loc
   | Abort Loc
-  | Assign [Name] [TypedExpr] Loc
-  | AAssign TypedExpr TypedExpr TypedExpr Loc
-  | Assert TypedExpr Loc
-  | LoopInvariant TypedExpr TypedExpr Loc
-  | Do [TypedGdCmd] Loc
-  | If [TypedGdCmd] Loc
+  | Assign [Name] [Expr] Loc
+  | AAssign Expr Expr Expr Loc
+  | Assert Expr Loc
+  | LoopInvariant Expr Expr Loc
+  | Do [GdCmd] Loc
+  | If [GdCmd] Loc
   | Spec Text Range TypeEnv
   | Proof Text Text Range
-  | Alloc   Name [TypedExpr] Loc    --  p := new (e1,e2,..,en)
-  | HLookup Name TypedExpr Loc      --  x := *e
-  | HMutate TypedExpr TypedExpr Loc --  *e1 := e2
-  | Dispose TypedExpr Loc           --  dispose e
-  | Block TypedProgram Loc
+  | Alloc   Name [Expr] Loc    --  p := new (e1,e2,..,en)
+  | HLookup Name Expr Loc      --  x := *e
+  | HMutate Expr Expr Loc --  *e1 := e2
+  | Dispose Expr Loc           --  dispose e
+  | Block Program Loc
   deriving (Eq, Show)
 
-data TypedGdCmd = TypedGdCmd TypedExpr [TypedStmt] Loc
+data GdCmd = GdCmd Expr [Stmt] Loc
   deriving (Eq, Show)
 
-data TypedExpr
+data Expr
   = Lit Lit Type Loc
   | Var Name Type Loc
   | Const Name Type Loc
   | Op Op Type
-  | Chain TypedChain
-  | App TypedExpr TypedExpr Loc
-  | Lam Name Type TypedExpr Loc
-  | Quant TypedExpr [Name] TypedExpr TypedExpr Loc
-  | ArrIdx TypedExpr TypedExpr Loc
-  | ArrUpd TypedExpr TypedExpr TypedExpr Loc
+  | Chain Chain
+  | App Expr Expr Loc
+  | Lam Name Type Expr Loc
+  | Quant Expr [Name] Expr Expr Loc
+  | ArrIdx Expr Expr Loc
+  | ArrUpd Expr Expr Expr Loc
   deriving (Eq, Show)
   -- FIXME: Other constructors.
 
-data TypedChain
-  = Pure TypedExpr
-  | More TypedChain Op Type TypedExpr
+data Chain
+  = Pure Expr
+  | More Chain Op Type Expr
   deriving (Eq, Show)


### PR DESCRIPTION
A simple refactoring: removed the "Typed" prefix in the names of datatypes in Syntax.Typed.