### PR TITLE
Fix a bug due to abusing the state variable.

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -17,7 +17,7 @@ main = do
   case mode of
     ModeHelp -> putStrLn $ usageInfo usage options
     ModeLSP -> do
-      _ <- runOnStdio "/Users/vince/Documents/gcl-vscode/server_log.txt"
+      _ <- runOnStdio "c:\\Users\\andys\\OneDrive\\Desktop\\server_log.txt"
       return ()
     ModeDev -> do
       _ <- runOnPort port

--- a/gcl.cabal
+++ b/gcl.cabal
@@ -72,7 +72,6 @@ library
       Server.IntervalMap
       Server.Load
       Server.Monad
-      Server.Notification.Error
       Server.Notification.Update
       Server.PositionMapping
       Server.SrcLoc
@@ -241,7 +240,6 @@ test-suite gcl-test
       Server.IntervalMap
       Server.Load
       Server.Monad
-      Server.Notification.Error
       Server.Notification.Update
       Server.PositionMapping
       Server.SrcLoc

--- a/src/GCL/Common.hs
+++ b/src/GCL/Common.hs
@@ -20,6 +20,21 @@ import           Syntax.Common.Types
 
 data Index = Index Name | Hole Range deriving (Eq, Show, Ord)
 
+data TypeInfo =
+    TypeDefnCtorInfo Type
+    | ConstTypeInfo Type
+    | VarTypeInfo Type
+    deriving (Eq, Show)
+
+toTypeEnv :: [(Index, TypeInfo)] -> TypeEnv
+toTypeEnv infos =
+  (\(index, info) ->
+    case info of
+      TypeDefnCtorInfo ty -> (index, ty)
+      ConstTypeInfo ty -> (index, ty)
+      VarTypeInfo ty -> (index, ty)
+  ) <$> infos
+
 type TypeEnv = [(Index, Type)]
 
 -- get a fresh variable

--- a/src/GCL/Common.hs
+++ b/src/GCL/Common.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleInstances, UndecidableInstances,
              MultiParamTypeClasses, FlexibleContexts #-}
+{-# LANGUAGE DeriveGeneric #-}
 module GCL.Common where
 
 import           Control.Monad.RWS              ( RWST(..) )
@@ -16,6 +17,7 @@ import qualified Data.Text                     as Text
 import           Data.Loc.Range                 ( Range )
 import           Syntax.Abstract
 import           Syntax.Common.Types
+import    GHC.Generics
 
 
 data Index = Index Name | Hole Range deriving (Eq, Show, Ord)
@@ -24,7 +26,7 @@ data TypeInfo =
     TypeDefnCtorInfo Type
     | ConstTypeInfo Type
     | VarTypeInfo Type
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic)
 
 toTypeEnv :: [(Index, TypeInfo)] -> TypeEnv
 toTypeEnv infos =

--- a/src/GCL/Predicate.hs
+++ b/src/GCL/Predicate.hs
@@ -20,7 +20,6 @@ import           GCL.Common
 import           Render.Element
 import           Syntax.Typed                   ( Expr )
 import           Syntax.Common                  ( Name )
-
 -- | A predicate is an expression, whose type happens to be Bool.
 type Pred = Expr
 
@@ -167,7 +166,7 @@ data Spec = Specification
   , specPreCond  :: Pred
   , specPostCond :: Pred
   , specRange    :: Range
-  , specTypeEnv  :: TypeEnv
+  , specTypeEnv  :: [(Index, TypeInfo)]
   }
   deriving (Eq, Show, Generic)
 

--- a/src/GCL/WP/Util.hs
+++ b/src/GCL/WP/Util.hs
@@ -26,6 +26,8 @@ import           GCL.Common                     ( Fresh(..)
                                                 , Counterous(..)
                                                 , TypeEnv
                                                 , freshName'
+                                                , Index
+                                                , TypeInfo
                                                 )
 
 import           Syntax.Typed
@@ -94,7 +96,7 @@ tellPO p q origin = unless (p == q) $ do
 tellPO' :: Origin -> Pred -> Pred -> WP ()
 tellPO' l p q = tellPO p q l
 
-tellSpec :: Pred -> Pred -> TypeEnv -> Range -> WP ()
+tellSpec :: Pred -> Pred -> [(Index, TypeInfo)] -> Range -> WP ()
 tellSpec p q typeEnv l = do
   -- p' <- substitute [] [] p
   -- q' <- substitute [] [] q

--- a/src/Server/Handler/Guabao/Refine.hs
+++ b/src/Server/Handler/Guabao/Refine.hs
@@ -23,7 +23,7 @@ import Language.Lexer.Applicative              ( TokenStream(..))
 
 import Error (Error (ParseError, TypeError, StructError, Others))
 import GCL.Predicate (Spec(..), PO, InfMode(..))
-import GCL.Common (TypeEnv)
+import GCL.Common (TypeEnv, Index, TypeInfo)
 import GCL.Type (Elab(..), TypeError, runElaboration, Typed)
 import Data.Loc.Range (Range (..), rangeStart)
 import Data.Text (Text, split, unlines, lines)
@@ -108,7 +108,7 @@ handler _params@RefineParams{filePath, specLines, implText} onFinish _ = do
                     Just spec -> do
                       logText "  matching spec found\n"
                       -- elaborate
-                      let typeEnv :: TypeEnv = specTypeEnv spec
+                      let typeEnv = specTypeEnv spec
                       logText " type env:\n"
                       logText (Text.pack $ show typeEnv)
                       logText "\n"
@@ -243,7 +243,7 @@ toAbstractFragment concreteFragment =
     Left _                 -> Nothing
     Right abstractFragment -> Just abstractFragment
 
-elaborateFragment :: Elab a => TypeEnv -> a -> Either TypeError (Typed a)
+elaborateFragment :: Elab a => [(Index, TypeInfo)] -> a -> Either TypeError (Typed a)
 elaborateFragment typeEnv abstractFragment = do
   runElaboration abstractFragment typeEnv
 

--- a/src/Syntax/Typed/Types.hs
+++ b/src/Syntax/Typed/Types.hs
@@ -8,7 +8,7 @@ import Data.Loc ( Loc )
 import Data.Loc.Range ( Range )
 import Syntax.Abstract.Types ( Lit(..), Type(..), TBase(..) )
 import Syntax.Common.Types ( Name, Op )
-import GCL.Common ( TypeEnv )
+import GCL.Common ( TypeEnv, Index, TypeInfo )
 
 data Program = Program [Definition] -- definitions (the functional language part)
                        [Declaration] -- constant and variable declarations
@@ -40,7 +40,7 @@ data Stmt
   | LoopInvariant Expr Expr Loc
   | Do [GdCmd] Loc
   | If [GdCmd] Loc
-  | Spec Text Range TypeEnv
+  | Spec Text Range [(Index, TypeInfo)]
   | Proof Text Text Range
   | Alloc   Name [Expr] Loc    --  p := new (e1,e2,..,en)
   | HLookup Name Expr Loc      --  x := *e


### PR DESCRIPTION
@B04902047
I changed the type of the extra information in the spec from `TypeEnv` (`[(Index, Type)]`) to `[(Index, TypeInfo)]`.
It seems that the front-end also need to be adjusted to reflect this change.
Please help me fix the front-end and tell me if it works.